### PR TITLE
Make `zsh` autocompletion work on macOS

### DIFF
--- a/home/zsh.nix
+++ b/home/zsh.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ lib, pkgs, ... }:
 
 {
   programs.zsh = {
@@ -19,11 +19,6 @@
     initExtra = ''
       # Show random quote: https://github.com/srid/actual
       ${lib.getExe pkgs.actual}
-    '';
-
-    initExtraBeforeCompInit = ''
-      # Fix broken autocompletion. See https://github.com/nix-community/home-manager/issues/2562.
-      fpath+=("${config.home.profileDirectory}"/share/zsh/site-functions "${config.home.profileDirectory}"/share/zsh/$ZSH_VERSION/functions "${config.home.profileDirectory}"/share/zsh/vendor-completions)
     '';
   };
 }

--- a/home/zsh.nix
+++ b/home/zsh.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   programs.zsh = {
@@ -19,6 +19,11 @@
     initExtra = ''
       # Show random quote: https://github.com/srid/actual
       ${lib.getExe pkgs.actual}
+    '';
+
+    initExtraBeforeCompInit = ''
+      # Fix broken autocompletion. See https://github.com/nix-community/home-manager/issues/2562.
+      fpath+=("${config.home.profileDirectory}"/share/zsh/site-functions "${config.home.profileDirectory}"/share/zsh/$ZSH_VERSION/functions "${config.home.profileDirectory}"/share/zsh/vendor-completions)
     '';
   };
 }

--- a/nix-darwin/zsh-completion-fix.nix
+++ b/nix-darwin/zsh-completion-fix.nix
@@ -1,0 +1,16 @@
+# Fix broken autocompletion. See https://github.com/nix-community/home-manager/issues/2562.
+{ flake, ... }:
+
+{
+  home-manager.users.${flake.config.people.myself}.imports = [
+    ({ config, ... }: {
+      programs.zsh.initExtraBeforeCompInit = ''
+        fpath+=("${config.home.profileDirectory}"/share/zsh/site-functions "${config.home.profileDirectory}"/share/zsh/$ZSH_VERSION/functions "${config.home.profileDirectory}"/share/zsh/vendor-completions)
+      '';
+    })
+  ];
+
+  # Even though we enable zsh in home-manager, we still need to enable to
+  # nix-darwin module to make completions work.
+  programs.zsh.enable = true;
+}

--- a/nix-darwin/zsh-completion-fix.nix
+++ b/nix-darwin/zsh-completion-fix.nix
@@ -10,7 +10,7 @@
     })
   ];
 
-  # Even though we enable zsh in home-manager, we still need to enable to
+  # Even though we enable zsh in home-manager, we still need to enable the
   # nix-darwin module to make completions work.
   programs.zsh.enable = true;
 }

--- a/systems/darwin.nix
+++ b/systems/darwin.nix
@@ -1,4 +1,4 @@
-{ pkgs, flake, ... }:
+{ config, pkgs, flake, ... }:
 
 # See nix-darwin/default.nix for other modules in use.
 {
@@ -9,10 +9,13 @@
 
   nixpkgs.hostPlatform = "aarch64-darwin";
 
-  environment.systemPackages = with pkgs; [
-    # macOS GUI programs
-    wezterm
-  ];
+  environment = {
+    systemPackages = with pkgs; [
+      # macOS GUI programs
+      wezterm
+    ];
+    pathsToLink = [ "/share/zsh" ];
+  };
 
   security.pam.enableSudoTouchIdAuth = true;
 

--- a/systems/darwin.nix
+++ b/systems/darwin.nix
@@ -1,21 +1,19 @@
-{ config, pkgs, flake, ... }:
+{ pkgs, flake, ... }:
 
 # See nix-darwin/default.nix for other modules in use.
 {
   imports = [
     flake.inputs.self.darwinModules.default
     ../nix-darwin/ci.nix
+    ../nix-darwin/zsh-completion-fix.nix
   ];
 
   nixpkgs.hostPlatform = "aarch64-darwin";
 
-  environment = {
-    systemPackages = with pkgs; [
-      # macOS GUI programs
-      wezterm
-    ];
-    pathsToLink = [ "/share/zsh" ];
-  };
+  environment.systemPackages = with pkgs; [
+    # macOS GUI programs
+    wezterm
+  ];
 
   security.pam.enableSudoTouchIdAuth = true;
 


### PR DESCRIPTION
<img width="443" alt="image" src="https://github.com/srid/nixos-config/assets/3998/a57237c9-0ad7-41bb-9d96-def2e2065de3">

cf. https://github.com/nix-community/home-manager/issues/2562

