### PR TITLE
pureintent: add devbox.nix with proxychains + devbox-run wrapper

### DIFF
--- a/configurations/nixos/pureintent/default.nix
+++ b/configurations/nixos/pureintent/default.nix
@@ -25,6 +25,7 @@ in
   imports = [
     self.nixosModules.default
     ./configuration.nix
+    ./devbox.nix
     (self + /modules/nixos/linux/beszel.nix)
     (self + /modules/nixos/linux/incus)
   ];

--- a/configurations/nixos/pureintent/devbox.nix
+++ b/configurations/nixos/pureintent/devbox.nix
@@ -1,0 +1,33 @@
+# Depends on programs.jumphost.socks5Proxy (https://github.com/srid/jumphost-nix)
+# for the local SOCKS5 listener. See modules/home/work/juspay.nix:29-31.
+{ config, flake, pkgs, ... }:
+
+let
+  socksPort = config.home-manager.users.${flake.config.me.username}.programs.jumphost.socks5Proxy.port;
+
+  proxychainsBin = "${config.programs.proxychains.package}/bin/proxychains4";
+
+  devbox-run = pkgs.writeShellScriptBin "devbox-run" ''
+    export ALL_PROXY=socks5://127.0.0.1:${toString socksPort}
+    export HTTPS_PROXY=socks5://127.0.0.1:${toString socksPort}
+    export HTTP_PROXY=socks5://127.0.0.1:${toString socksPort}
+    exec ${proxychainsBin} "$@"
+  '';
+in
+{
+  programs.proxychains = {
+    enable = true;
+    chain.type = "strict";
+    proxyDNS = true;
+    proxies.devbox = {
+      enable = true;
+      type = "socks5";
+      host = "127.0.0.1";
+      port = socksPort;
+    };
+  };
+
+  environment.systemPackages = [
+    devbox-run
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `configurations/nixos/pureintent/devbox.nix` which enables `programs.proxychains` and ships a `devbox-run` wrapper that exports `ALL_PROXY` / `HTTPS_PROXY` / `HTTP_PROXY` before exec'ing `proxychains4 "$@"`.
- Reuses the existing `programs.jumphost.socks5Proxy` (see `modules/home/work/juspay.nix:29-31`) for the local SOCKS5 listener instead of standing up a second tunnel.

## Test plan
- [x] `nix build .#nixosConfigurations.pureintent.config.system.build.toplevel` succeeds
- [x] Deploy via `just activate pureintent`
- [x] `/etc/proxychains.conf` contains `socks5 127.0.0.1 1080` (per-proxy `enable = true` required, otherwise `[ProxyList]` is empty)
- [ ] `devbox-run nix run github:juspay/project-unknown -- connect <name>` reaches the target via vanjaram

🤖 Generated with [Claude Code](https://claude.com/claude-code)