### PR TITLE
pureintent: rename devbox-run to vanjaram-run

### DIFF
--- a/configurations/nixos/pureintent/devbox.nix
+++ b/configurations/nixos/pureintent/devbox.nix
@@ -7,7 +7,7 @@ let
 
   proxychainsBin = "${config.programs.proxychains.package}/bin/proxychains4";
 
-  devbox-run = pkgs.writeShellScriptBin "devbox-run" ''
+  vanjaram-run = pkgs.writeShellScriptBin "vanjaram-run" ''
     export ALL_PROXY=socks5://127.0.0.1:${toString socksPort}
     export HTTPS_PROXY=socks5://127.0.0.1:${toString socksPort}
     export HTTP_PROXY=socks5://127.0.0.1:${toString socksPort}
@@ -28,6 +28,6 @@ in
   };
 
   environment.systemPackages = [
-    devbox-run
+    vanjaram-run
   ];
 }


### PR DESCRIPTION
## Summary
- The wrapper specifically routes through vanjaram (via the configured jumphost SOCKS5 proxy); naming it after the host makes that explicit at the call site.

## Test plan
- [x] `nix build .#nixosConfigurations.pureintent.config.system.build.toplevel` succeeds
- [ ] `vanjaram-run nix run github:juspay/project-unknown -- connect <name>` works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)