### PR TITLE
pureintent: include ~/.pu-state/*/ssh_config in ~/.ssh/config

### DIFF
--- a/configurations/nixos/pureintent/devbox.nix
+++ b/configurations/nixos/pureintent/devbox.nix
@@ -42,4 +42,10 @@ in
     vanjaram-run
     pu
   ];
+
+  # pu writes per-instance ssh_config files under ~/.pu-state/<name>/.
+  # Including them lets `ssh <name>` work directly without `pu connect`.
+  home-manager.users.${flake.config.me.username}.programs.ssh.includes = [
+    "~/.pu-state/*/ssh_config"
+  ];
 }

--- a/configurations/nixos/pureintent/devbox.nix
+++ b/configurations/nixos/pureintent/devbox.nix
@@ -43,9 +43,15 @@ in
     pu
   ];
 
-  # pu writes per-instance ssh_config files under ~/.pu-state/<name>/.
-  # Including them lets `ssh <name>` work directly without `pu connect`.
-  home-manager.users.${flake.config.me.username}.programs.ssh.includes = [
-    "~/.pu-state/*/ssh_config"
-  ];
+  # pu writes per-instance ssh_config files under ~/.pu-state/<name>/. Including
+  # them lets `ssh <name>` work directly. The inner ssh those configs spawn goes
+  # to `pu@<PU_HOST>` which is only reachable via vanjaram — route any ssh to
+  # user `pu` through the SOCKS5 proxy.
+  home-manager.users.${flake.config.me.username}.programs.ssh = {
+    includes = [ "~/.pu-state/*/ssh_config" ];
+    matchBlocks."pu-jumphost" = {
+      match = "user pu";
+      proxyCommand = "${pkgs.netcat-openbsd}/bin/nc -X 5 -x 127.0.0.1:${toString socksPort} %h %p";
+    };
+  };
 }


### PR DESCRIPTION
## Summary
- Adds `Include ~/.pu-state/*/ssh_config` to the user's `~/.ssh/config` so `ssh <name>` works directly after `pu create`/`pu connect` writes the per-instance ssh_config.

## Test plan
- [x] Deploys on pureintent
- [ ] `pu connect <name>` once, then plain `ssh <name>` works without `pu connect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)