### PR TITLE
ralph(eval): reduce Nix eval time for pureintent + zest

### DIFF
--- a/configurations/nixos/pureintent/configuration.nix
+++ b/configurations/nixos/pureintent/configuration.nix
@@ -81,6 +81,11 @@
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;
 
+  # The NixOS options manual is rarely consulted locally (options are searched
+  # online), but generating it evaluates the doc string of every option — a
+  # measurable chunk of eval time. Package man pages (`man git`) are unaffected.
+  documentation.nixos.enable = false;
+
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [

--- a/docs/eval-bench.sh
+++ b/docs/eval-bench.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Ralph eval-time benchmark — counter-based.
-# Usage: ralph-bench.sh [target]   target = pureintent | zest | (both)
+# Usage: ralph-bench.sh [target]   target = pureintent | sincereintent | (both)
 #
 # Primary metric: deterministic eval-work counters from NIX_SHOW_STATS:
 #   nrThunks, nrFunctionCalls, nrPrimOpCalls.
@@ -17,11 +17,11 @@ ONLY="${1:-}"
 
 declare -A ATTR
 ATTR[pureintent]="$FLAKE#nixosConfigurations.pureintent.config.system.build.toplevel.drvPath"
-ATTR[zest]="$FLAKE#homeConfigurations.\"srid@zest\".activationPackage.drvPath"
+ATTR[sincereintent]="$FLAKE#homeConfigurations.\"srid@sincereintent\".activationPackage.drvPath"
 
 num() { grep -o "\"$1\": [0-9.]*" /tmp/ralph-stats.json | grep -o '[0-9.]*' | head -1; }
 
-for target in pureintent zest; do
+for target in pureintent sincereintent; do
   [ -n "$ONLY" ] && [ "$ONLY" != "$target" ] && continue
   NIX_SHOW_STATS=1 nix eval --raw "${ATTR[$target]}" --option eval-cache false \
     >/dev/null 2>/tmp/ralph-stats.json

--- a/docs/eval-bench.sh
+++ b/docs/eval-bench.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Ralph eval-time benchmark.
+# Usage: ralph-bench.sh <runs>
+# Primary metric: median cpuTime (NIX_SHOW_STATS) — stable, isolates eval work.
+# Secondary: median wall-clock (noisy, IO-bound).
+# Eval cache disabled; fetcher cache warm via persistent $HOME.
+set -uo pipefail
+
+RUNS="${1:-5}"
+export HOME=/tmp/ralph-evalhome
+mkdir -p "$HOME"
+FLAKE="${FLAKE:-/home/srid/code/nixos-config/.worktrees/ralph}"
+
+declare -A ATTR
+ATTR[pureintent]="$FLAKE#nixosConfigurations.pureintent.config.system.build.toplevel.drvPath"
+ATTR[zest]="$FLAKE#homeConfigurations.\"srid@zest\".activationPackage.drvPath"
+
+median() { sort -n | awk '{a[NR]=$1} END{ if(NR%2){print a[(NR+1)/2]} else {print (a[NR/2]+a[NR/2+1])/2} }'; }
+now_ms() { date +%s%3N; }
+
+for target in pureintent zest; do
+  attr="${ATTR[$target]}"
+  cpus=(); walls=()
+  for i in $(seq 1 "$RUNS"); do
+    start=$(now_ms)
+    NIX_SHOW_STATS=1 nix eval --raw "$attr" --option eval-cache false \
+      >/dev/null 2>/tmp/ralph-stats.json
+    rc=$?
+    end=$(now_ms)
+    if [ $rc -ne 0 ]; then echo "$target run $i FAILED (rc=$rc)"; tail -8 /tmp/ralph-stats.json; exit 1; fi
+    cpu=$(grep -o '"cpuTime": [0-9.]*' /tmp/ralph-stats.json | head -1 | grep -o '[0-9.]*')
+    cpus+=("$cpu"); walls+=("$((end - start))")
+  done
+  medcpu=$(printf '%s\n' "${cpus[@]}" | median)
+  medwall=$(printf '%s\n' "${walls[@]}" | median)
+  medwall_s=$(awk "BEGIN{printf \"%.2f\", $medwall/1000}")
+  printf '%-11s cpuTime=%ss (median of %d) | wall=%ss | cpu=[%s] wall_ms=[%s]\n' \
+    "$target" "$medcpu" "$RUNS" "$medwall_s" "${cpus[*]}" "${walls[*]}"
+done

--- a/docs/eval-bench.sh
+++ b/docs/eval-bench.sh
@@ -1,39 +1,32 @@
 #!/usr/bin/env bash
-# Ralph eval-time benchmark.
-# Usage: ralph-bench.sh <runs>
-# Primary metric: median cpuTime (NIX_SHOW_STATS) — stable, isolates eval work.
-# Secondary: median wall-clock (noisy, IO-bound).
+# Ralph eval-time benchmark — counter-based.
+# Usage: ralph-bench.sh [target]   target = pureintent | zest | (both)
+#
+# Primary metric: deterministic eval-work counters from NIX_SHOW_STATS:
+#   nrThunks, nrFunctionCalls, nrPrimOpCalls.
+# These are byte-identical across runs (independent of CPU clock/load), so a
+# single eval gives an exact number. cpuTime is NOT used: this machine thermally
+# throttles, inflating CPU-seconds for identical work (11s..21s for one eval).
 # Eval cache disabled; fetcher cache warm via persistent $HOME.
 set -uo pipefail
 
-RUNS="${1:-5}"
 export HOME=/tmp/ralph-evalhome
 mkdir -p "$HOME"
 FLAKE="${FLAKE:-/home/srid/code/nixos-config/.worktrees/ralph}"
+ONLY="${1:-}"
 
 declare -A ATTR
 ATTR[pureintent]="$FLAKE#nixosConfigurations.pureintent.config.system.build.toplevel.drvPath"
 ATTR[zest]="$FLAKE#homeConfigurations.\"srid@zest\".activationPackage.drvPath"
 
-median() { sort -n | awk '{a[NR]=$1} END{ if(NR%2){print a[(NR+1)/2]} else {print (a[NR/2]+a[NR/2+1])/2} }'; }
-now_ms() { date +%s%3N; }
+num() { grep -o "\"$1\": [0-9.]*" /tmp/ralph-stats.json | grep -o '[0-9.]*' | head -1; }
 
 for target in pureintent zest; do
-  attr="${ATTR[$target]}"
-  cpus=(); walls=()
-  for i in $(seq 1 "$RUNS"); do
-    start=$(now_ms)
-    NIX_SHOW_STATS=1 nix eval --raw "$attr" --option eval-cache false \
-      >/dev/null 2>/tmp/ralph-stats.json
-    rc=$?
-    end=$(now_ms)
-    if [ $rc -ne 0 ]; then echo "$target run $i FAILED (rc=$rc)"; tail -8 /tmp/ralph-stats.json; exit 1; fi
-    cpu=$(grep -o '"cpuTime": [0-9.]*' /tmp/ralph-stats.json | head -1 | grep -o '[0-9.]*')
-    cpus+=("$cpu"); walls+=("$((end - start))")
-  done
-  medcpu=$(printf '%s\n' "${cpus[@]}" | median)
-  medwall=$(printf '%s\n' "${walls[@]}" | median)
-  medwall_s=$(awk "BEGIN{printf \"%.2f\", $medwall/1000}")
-  printf '%-11s cpuTime=%ss (median of %d) | wall=%ss | cpu=[%s] wall_ms=[%s]\n' \
-    "$target" "$medcpu" "$RUNS" "$medwall_s" "${cpus[*]}" "${walls[*]}"
+  [ -n "$ONLY" ] && [ "$ONLY" != "$target" ] && continue
+  NIX_SHOW_STATS=1 nix eval --raw "${ATTR[$target]}" --option eval-cache false \
+    >/dev/null 2>/tmp/ralph-stats.json
+  if [ $? -ne 0 ]; then echo "$target FAILED"; tail -8 /tmp/ralph-stats.json; exit 1; fi
+  printf '%-11s thunks=%-10s calls=%-10s primops=%-9s | values=%s sets=%s\n' \
+    "$target" "$(num nrThunks)" "$(num nrFunctionCalls)" "$(num nrPrimOpCalls)" \
+    "$(num number)" "$(grep -o '"sets": {[^}]*"number": [0-9]*' /tmp/ralph-stats.json | grep -o '[0-9]*$')"
 done

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -8,16 +8,22 @@ configs that get evaluated most often on this machine:
 
 ## Methodology
 
-Primary metric: **`cpuTime`** from `NIX_SHOW_STATS=1` — it isolates pure
-evaluation work and is stable run-to-run (~3% spread). Wall-clock is reported
-too but is IO/cache-bound and noisy (±15%), so it is *not* used for commit
-decisions.
+Primary metric: **deterministic eval-work counters** from `NIX_SHOW_STATS=1` —
+`nrThunks`, `nrFunctionCalls`, `nrPrimOpCalls`. These count the actual evaluation
+work and are **byte-identical across runs** (independent of CPU clock, load, GC).
+
+> **Why not `cpuTime`/wall?** Initially planned, but rejected after measuring:
+> this is a live, thermally-throttling laptop. The *same* eval (identical
+> nrThunks every run) reported cpuTime climbing 11s → 21s monotonically as the
+> CPU clock dropped under sustained load. Time is meaningless here; counters are
+> exact. A 1% drop in nrThunks is a real 1% less work the evaluator must do, on
+> any machine. Single eval per target — no median needed.
 
 ```sh
-# docs/eval-bench.sh <runs>   (default 5)
+# docs/eval-bench.sh [target]      target = pureintent | zest | (both)
 # - persistent $HOME=/tmp/ralph-evalhome keeps the fetcher/git cache warm
 # - --option eval-cache false forces a full re-eval every run
-# - reports median cpuTime + median wall over N runs, per target
+# - reports nrThunks / nrFunctionCalls / nrPrimOpCalls per target (deterministic)
 nix eval --raw .#nixosConfigurations.pureintent.config.system.build.toplevel.drvPath --option eval-cache false
 nix eval --raw '.#homeConfigurations."srid@zest".activationPackage.drvPath'        --option eval-cache false
 ```
@@ -25,25 +31,31 @@ nix eval --raw '.#homeConfigurations."srid@zest".activationPackage.drvPath'     
 No `nix store gc` between runs (per request). The eval cache is disabled rather
 than cleared, so the warm fetcher cache removes input-fetch noise.
 
-**Commit rule:** commit only if median cpuTime improves >3% for a target with no
-regression on the other. Behaviour may change *only* by dropping inputs/features
-first confirmed unused.
+**Commit rule:** commit only if `nrThunks` improves >3% for a target with no
+regression on the other. (Counters have ~zero noise, so any real reduction
+counts; >3% is the bar for a "meaningful" cycle.) Behaviour may change *only* by
+dropping inputs/features first confirmed unused.
 
-## Baseline (median of 5)
+Profiling tool: `nix eval … --eval-profiler flamegraph --eval-profile-file f`
+then aggregate self/inclusive frames (collapsed-stack format).
 
-| Target     | cpuTime (s) | wall (s) | cpuTime runs |
-|------------|-------------|----------|--------------|
-| pureintent | **23.17**   | 38.91    | 21.99 / 23.45 / 23.76 / 23.17 / 22.74 |
-| zest       | **14.93**   | 22.09    | 14.93 / 14.50 / 13.86 / 15.49 / 14.96 |
+## Baseline (nrThunks / nrFunctionCalls / nrPrimOpCalls)
 
-Env: nix 2.34.7, x86_64-linux. Stats at baseline (pureintent): nrThunks 20.4M,
-nrFunctionCalls 13.0M, sets.bytes 868MB, values.bytes 503MB, gcFraction 0.058.
+| Target     | nrThunks   | nrFunctionCalls | nrPrimOpCalls |
+|------------|------------|-----------------|---------------|
+| pureintent | 20,400,114 | 12,975,268      | 6,507,025     |
+| zest       | 11,066,680 |  7,091,428      | 3,587,586     |
+
+Env: nix 2.34.7, x86_64-linux.
 
 ## Optimization log
 
-| Cycle | Change | pureintent | zest | Verdict |
-|-------|--------|------------|------|---------|
-| 0 | baseline | 23.17 | 14.93 | — |
+(Δ% is on nrThunks vs baseline for the affected target.)
+
+| Cycle | Change | pureintent thunks | zest thunks | Verdict |
+|-------|--------|-------------------|-------------|---------|
+| 0 | baseline | 20,400,114 | 11,066,680 | — |
+| 1 | pureintent: `documentation.nixos.enable = false` (drop NixOS options manual; option doc-strings no longer evaluated) | **19,201,996 (−5.9%)** | 11,066,680 | ✅ commit |
 
 ## Dead ends
 

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -62,9 +62,38 @@ Env: nix 2.34.7, x86_64-linux.
 > home-manager via `modules/nixos/default.nix`, so cycle 2 reduced pureintent
 > too (its HM user's manpages were previously on).
 
+| 3 | (profiling cycle — no change) investigated nixpkgs double-instantiation, unused inputs, `escapeShellArg` hotspot | 17,431,437 | 3,551,679 | — no behaviour-preserving win found |
+
 ## Dead ends
 
 _(investigated, no improvement — recorded so we don't retry)_
+
+- **nixpkgs is NOT double-instantiated.** `nixos-unified.lib.mkLinuxSystem` calls
+  `nixpkgs.lib.nixosSystem` without pinning `nixpkgs.pkgs`, but the NixOS
+  `nixpkgs` module imports the package set exactly once; the `pkgs/top-level/impure.nix`
+  frame in the profile is that single import. `home-manager.useGlobalPkgs = true`
+  (set by nixos-unified) already shares it with the embedded HM. No win available.
+- **Dropping unused flake inputs does not reduce eval counters.** Nix input
+  evaluation is lazy: an input not referenced during a config's eval (e.g.
+  `nixos-hardware`, `git-hooks` — 0 refs) contributes ~0 thunks to that config.
+  Pruning them shrinks `flake.lock`/`nix flake` overhead only, not `nrThunks`.
+- **`escapeShellArg` (~72% inclusive on pureintent) is not a fixable hotspot.**
+  It is driven by `home-manager` file-linking (`files.nix:442`, ~43% — one
+  escaped command per managed dotfile) and NixOS `/etc` generation
+  (`etc.nix:58`). Both scale with how much is managed; nixpkgs/HM own the
+  implementation. Not patchable from this repo.
+- **`programs.command-not-found` already disabled** by the `nix-index-database`
+  module; nothing to gain.
+
+## Remaining cost is feature-bound
+
+After the two documentation wins, the dominant `derivationStrict` targets in the
+pureintent eval profile are all *wanted* features (samples ≈ inclusive share):
+`home-manager-generation`/`home-manager-files` (~43%, embedded HM), `/etc`
+(~29%), `vira.service`+`vira-wrapped`+`vira-0.1.0.0` (Haskell app), `kolu.service`,
+`pipewire`, plus heavy packages in `home.packages` (`google-cloud-sdk`, `pandoc`,
+`omnix` — Haskell). Further reductions require trading a feature, not a free
+structural change.
 
 ## Key findings
 

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -4,7 +4,7 @@ Iterative measurement-driven reduction of Nix **evaluation** time for the two
 configs that get evaluated most often on this machine:
 
 - `pureintent` — the NixOS system (`nixosConfigurations.pureintent`)
-- `zest` — the home-manager config (`homeConfigurations."srid@zest"`)
+- `sincereintent` — the home-manager config (`homeConfigurations."srid@sincereintent"`)
 
 ## Methodology
 
@@ -25,7 +25,7 @@ work and are **byte-identical across runs** (independent of CPU clock, load, GC)
 # - --option eval-cache false forces a full re-eval every run
 # - reports nrThunks / nrFunctionCalls / nrPrimOpCalls per target (deterministic)
 nix eval --raw .#nixosConfigurations.pureintent.config.system.build.toplevel.drvPath --option eval-cache false
-nix eval --raw '.#homeConfigurations."srid@zest".activationPackage.drvPath'        --option eval-cache false
+nix eval --raw '.#homeConfigurations."srid@sincereintent".activationPackage.drvPath' --option eval-cache false
 ```
 
 No `nix store gc` between runs (per request). The eval cache is disabled rather
@@ -43,8 +43,8 @@ then aggregate self/inclusive frames (collapsed-stack format).
 
 | Target     | nrThunks   | nrFunctionCalls | nrPrimOpCalls |
 |------------|------------|-----------------|---------------|
-| pureintent | 20,400,114 | 12,975,268      | 6,507,025     |
-| zest       | 11,066,680 |  7,091,428      | 3,587,586     |
+| pureintent    | 20,400,114 | 12,975,268      | 6,507,025     |
+| sincereintent |  5,323,428 |  3,227,404      | 1,565,120     |
 
 Env: nix 2.34.7, x86_64-linux.
 
@@ -52,10 +52,10 @@ Env: nix 2.34.7, x86_64-linux.
 
 (Δ% is on nrThunks vs baseline for the affected target.)
 
-| Cycle | Change | pureintent thunks | zest thunks | Verdict |
-|-------|--------|-------------------|-------------|---------|
-| 0 | baseline | 20,400,114 | 11,066,680 | — |
-| 1 | pureintent: `documentation.nixos.enable = false` (drop NixOS options manual; option doc-strings no longer evaluated) | **19,201,996 (−5.9%)** | 11,066,680 | ✅ commit |
+| Cycle | Change | pureintent thunks | sincereintent thunks | Verdict |
+|-------|--------|-------------------|----------------------|---------|
+| 0 | baseline | 20,400,114 | 5,323,428 | — |
+| 1 | pureintent: `documentation.nixos.enable = false` (drop NixOS options manual; option doc-strings no longer evaluated) | **19,201,996 (−5.9%)** | 5,323,428 | ✅ commit |
 
 ## Dead ends
 

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -63,6 +63,7 @@ Env: nix 2.34.7, x86_64-linux.
 > too (its HM user's manpages were previously on).
 
 | 3 | (profiling cycle — no change) investigated nixpkgs double-instantiation, unused inputs, `escapeShellArg` hotspot | 17,431,437 | 3,551,679 | — no behaviour-preserving win found |
+| 4 | home: drop heavy `home.packages` from shared `cli/terminal.nix` — `yt-dlp`, `lima`, `omnix`, `pandoc`, `google-cloud-sdk` (kept `hledger`). *Behaviour change, user-approved.* | **16,989,720 (−2.5%)** | **2,757,201 (−22.4%)** | ✅ commit |
 
 ## Dead ends
 

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -56,7 +56,11 @@ Env: nix 2.34.7, x86_64-linux.
 |-------|--------|-------------------|----------------------|---------|
 | 0 | baseline | 20,400,114 | 5,323,428 | — |
 | 1 | pureintent: `documentation.nixos.enable = false` (drop NixOS options manual; option doc-strings no longer evaluated) | **19,201,996 (−5.9%)** | 5,323,428 | ✅ commit |
-| 2 | home: `manual.manpages.enable = false` in shared `modules/home/default.nix` (drop home-manager options manpage; evaluated every HM option's doc) | 19,201,996 | **3,551,679 (−33.3%)** | ✅ commit |
+| 2 | home: `manual.manpages.enable = false` in shared `modules/home/default.nix` (drop home-manager options manpage; evaluated every HM option's doc) | **17,431,437 (−9.2%)** | **3,551,679 (−33.3%)** | ✅ commit |
+
+> Note: `modules/home/default.nix` is also fed to every Linux system's *embedded*
+> home-manager via `modules/nixos/default.nix`, so cycle 2 reduced pureintent
+> too (its HM user's manpages were previously on).
 
 ## Dead ends
 

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -96,6 +96,48 @@ pureintent eval profile are all *wanted* features (samples ≈ inclusive share):
 `omnix` — Haskell). Further reductions require trading a feature, not a free
 structural change.
 
+## Final measurement (median irrelevant — counters are exact)
+
+| Target | nrThunks (base → final) | Δ | nrFunctionCalls | nrPrimOpCalls |
+|--------|-------------------------|------|-----------------|---------------|
+| pureintent    | 20,400,114 → **16,989,720** | **−16.7%** | 12,975,268 → 10,794,555 (−16.8%) | 6,507,025 → 5,327,976 (−18.1%) |
+| sincereintent |  5,323,428 → **2,757,201** | **−48.2%** |  3,227,404 →  1,631,213 (−49.5%) | 1,565,120 →   771,171 (−50.7%) |
+
+Both configs still instantiate cleanly (`nix build --dry-run` on the system
+toplevel / home activationPackage succeeds).
+
 ## Key findings
 
-_(filled in at wrap-up)_
+1. **On a thermally-throttling machine, time is a lie — count work instead.**
+   The same eval reported cpuTime from 11s to 21s as the CPU clock sagged, while
+   `nrThunks` was byte-identical every run. Eval-work counters (`nrThunks`,
+   `nrFunctionCalls`, `nrPrimOpCalls`) are deterministic, zero-noise, and
+   machine-independent — a far better optimization metric than wall/cpu time.
+2. **Generated option documentation is the biggest free win.** The NixOS options
+   manual (`documentation.nixos.enable`) and the home-manager options manpage
+   (`manual.manpages.enable`) each evaluate the doc string of *every* option.
+   Disabling both: pureintent −14.6%, sincereintent −33% — with zero behaviour
+   cost (options are searched online).
+3. **A shared module multiplies.** `manual.manpages.enable = false` in
+   `modules/home/default.nix` helped both the standalone home config *and* every
+   Linux system's embedded home-manager (via `modules/nixos/default.nix`).
+4. **Eval is lazy — unused inputs are already free.** Pruning unreferenced flake
+   inputs does not move the counters; it only trims `flake.lock`.
+5. **The remainder is feature-bound.** After the doc wins, eval cost is dominated
+   by embedded home-manager file-linking, `/etc` generation, and the closures of
+   wanted services/packages. Trimming 5 heavy `home.packages` (user-approved) took
+   sincereintent to −48% total; the rest are features worth their eval cost.
+
+## Cost breakdown (per-package eval cost, standalone `pkgs.<p>.drvPath` thunks)
+
+Shared base floor ≈ 1.09M thunks; the excess is each package's own closure-eval:
+
+| Package | thunks | excess | removed? |
+|---------|--------|--------|----------|
+| yt-dlp | 2.15M | +1.05M | ✅ |
+| lima | 1.78M | +0.69M | ✅ |
+| omnix | 1.76M | +0.67M | ✅ |
+| pandoc | 1.46M | +0.37M | ✅ |
+| google-cloud-sdk | 1.39M | +0.30M | ✅ |
+| hledger | 1.35M | +0.26M | kept (wanted) |
+| ripgrep / fd / just / television | ~1.09M | ~0 | kept (at floor) |

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -56,6 +56,7 @@ Env: nix 2.34.7, x86_64-linux.
 |-------|--------|-------------------|----------------------|---------|
 | 0 | baseline | 20,400,114 | 5,323,428 | — |
 | 1 | pureintent: `documentation.nixos.enable = false` (drop NixOS options manual; option doc-strings no longer evaluated) | **19,201,996 (−5.9%)** | 5,323,428 | ✅ commit |
+| 2 | home: `manual.manpages.enable = false` in shared `modules/home/default.nix` (drop home-manager options manpage; evaluated every HM option's doc) | 19,201,996 | **3,551,679 (−33.3%)** | ✅ commit |
 
 ## Dead ends
 

--- a/docs/eval-time-ralph-report.md
+++ b/docs/eval-time-ralph-report.md
@@ -1,0 +1,54 @@
+# Nix Eval-Time Optimization (Ralph)
+
+Iterative measurement-driven reduction of Nix **evaluation** time for the two
+configs that get evaluated most often on this machine:
+
+- `pureintent` — the NixOS system (`nixosConfigurations.pureintent`)
+- `zest` — the home-manager config (`homeConfigurations."srid@zest"`)
+
+## Methodology
+
+Primary metric: **`cpuTime`** from `NIX_SHOW_STATS=1` — it isolates pure
+evaluation work and is stable run-to-run (~3% spread). Wall-clock is reported
+too but is IO/cache-bound and noisy (±15%), so it is *not* used for commit
+decisions.
+
+```sh
+# docs/eval-bench.sh <runs>   (default 5)
+# - persistent $HOME=/tmp/ralph-evalhome keeps the fetcher/git cache warm
+# - --option eval-cache false forces a full re-eval every run
+# - reports median cpuTime + median wall over N runs, per target
+nix eval --raw .#nixosConfigurations.pureintent.config.system.build.toplevel.drvPath --option eval-cache false
+nix eval --raw '.#homeConfigurations."srid@zest".activationPackage.drvPath'        --option eval-cache false
+```
+
+No `nix store gc` between runs (per request). The eval cache is disabled rather
+than cleared, so the warm fetcher cache removes input-fetch noise.
+
+**Commit rule:** commit only if median cpuTime improves >3% for a target with no
+regression on the other. Behaviour may change *only* by dropping inputs/features
+first confirmed unused.
+
+## Baseline (median of 5)
+
+| Target     | cpuTime (s) | wall (s) | cpuTime runs |
+|------------|-------------|----------|--------------|
+| pureintent | **23.17**   | 38.91    | 21.99 / 23.45 / 23.76 / 23.17 / 22.74 |
+| zest       | **14.93**   | 22.09    | 14.93 / 14.50 / 13.86 / 15.49 / 14.96 |
+
+Env: nix 2.34.7, x86_64-linux. Stats at baseline (pureintent): nrThunks 20.4M,
+nrFunctionCalls 13.0M, sets.bytes 868MB, values.bytes 503MB, gcFraction 0.058.
+
+## Optimization log
+
+| Cycle | Change | pureintent | zest | Verdict |
+|-------|--------|------------|------|---------|
+| 0 | baseline | 23.17 | 14.93 | — |
+
+## Dead ends
+
+_(investigated, no improvement — recorded so we don't retry)_
+
+## Key findings
+
+_(filled in at wrap-up)_

--- a/modules/home/cli/terminal.nix
+++ b/modules/home/cli/terminal.nix
@@ -17,29 +17,22 @@ in
     gnumake
     killall
     television
-    yt-dlp
     gh
     # Broken, https://github.com/NixOS/nixpkgs/issues/299680
     # ncdu
 
     # Useful for Nix development
     ci
-    omnix
     nixpkgs-fmt
     just
     watchexec
     fswatch
 
     eternal-terminal
-    lima
-
-    # AI
-    google-cloud-sdk
 
     # Publishing
     asciinema
     ispell
-    pandoc
 
     # Dev
     fuckport

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -3,6 +3,11 @@
   home.sessionVariables = {
     DO_NOT_TRACK = "1";
   };
+
+  # Home-manager generates an options manpage (`home-configuration.nix(5)`) by
+  # default, which evaluates the doc string of every HM option. Options are
+  # searched online, not via `man`, so skip it — measurable eval-time win.
+  manual.manpages.enable = false;
   imports = [
     ./cli/tmux.nix
     ./editors/neovim


### PR DESCRIPTION
Iterative measurement-driven reduction of Nix **evaluation** time, driven by the [ralph](https://github.com/srid/agency/blob/master/.apm/skills/ralph/SKILL.md) loop. Full log: `docs/eval-time-ralph-report.md`.

## Metric
Deterministic eval-work counters from `NIX_SHOW_STATS=1` (`nrThunks` / `nrFunctionCalls` / `nrPrimOpCalls`), eval cache off, warm fetcher cache. These are **byte-identical across runs** — `cpuTime` was rejected because this machine thermally throttles (same eval = 11s..21s). One eval per target is exact. See `docs/eval-bench.sh`.

## Results (nrThunks, baseline → final)
| Target | Baseline | Final | Δ |
|--------|----------|-------|---|
| pureintent | 20,400,114 | **16,989,720** | **−16.7%** |
| sincereintent | 5,323,428 | **2,757,201** | **−48.2%** |

(`nrFunctionCalls` and `nrPrimOpCalls` move proportionally; both configs still instantiate via `nix build --dry-run`.)

## Changes
1. **pureintent: `documentation.nixos.enable = false`** — drop the NixOS options manual (evaluates every option's doc string). −5.9%. Behaviour-preserving.
2. **home: `manual.manpages.enable = false`** in shared `modules/home/default.nix` — drop the home-manager options manpage. Helped sincereintent (−33%) *and* pureintent's embedded HM (−9.2%). Behaviour-preserving.
3. **home: dropped heavy `home.packages`** from shared `cli/terminal.nix` — `yt-dlp`, `lima`, `omnix`, `pandoc`, `google-cloud-sdk` (kept `hledger`). User-approved behaviour change; sincereintent −22.4%.

## Dead ends (documented in report)
- nixpkgs is **not** double-instantiated (nixos-unified imports it once; `useGlobalPkgs` shares it with HM).
- Pruning unused flake inputs does **not** reduce eval counters — input eval is lazy.
- The `escapeShellArg` ~72%-inclusive hotspot is HM file-linking + `/etc` generation — owned by nixpkgs/HM, not patchable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)