### PR TITLE
Self-host Atuin history sync on pureintent

### DIFF
--- a/configurations/nixos/naiveintent/default.nix
+++ b/configurations/nixos/naiveintent/default.nix
@@ -34,6 +34,7 @@ in
   home-manager.sharedModules = [
     "${homeMod}/gui/1password.nix"
     "${homeMod}/cli/odu.nix"
+    "${homeMod}/cli/atuin.nix"
     # Jump host SOCKS5 (jumphost-nix) — required by pu / juspay-run
     "${homeMod}/work/juspay.nix"
     # Juspay opencode config (juspay-ai) + llm-agents package

--- a/configurations/nixos/pureintent/default.nix
+++ b/configurations/nixos/pureintent/default.nix
@@ -35,6 +35,7 @@ in
     (self + /modules/nixos/linux/gc.nix)
     (self + /modules/nixos/linux/incus)
     (self + /modules/nixos/linux/llm-debugging.nix)
+    (self + /modules/nixos/linux/atuin.nix)
   ];
 
   # anywhen runs as an incus-pet container (see modules/nixos/linux/incus/incus-pet).
@@ -49,6 +50,7 @@ in
     "${homeMod}/cli/ssh-agent-forwarding.nix"
     "${homeMod}/cli/controlpersist.nix"
     "${homeMod}/cli/odu.nix"
+    "${homeMod}/cli/atuin.nix"
     "${homeMod}/claude-code"
     "${homeMod}/work/juspay.nix"
     "${homeMod}/work/opencode.nix"

--- a/modules/home/cli/atuin.nix
+++ b/modules/home/cli/atuin.nix
@@ -1,0 +1,19 @@
+# Atuin client (home-manager). Sync server: modules/nixos/linux/atuin.nix on pureintent.
+#
+# After deploy: `atuin register` / `atuin login` once; `atuin key` on other hosts.
+{
+  programs.atuin = {
+    enable = true;
+    enableBashIntegration = true;
+    enableZshIntegration = true;
+    settings = {
+      auto_sync = true;
+      sync_frequency = "5m";
+      sync_address = "http://pureintent.rooster-blues.ts.net:18888";
+      history_filter = [
+        "^export .*(KEY|TOKEN|SECRET|PASSWORD)="
+        "^.*API_KEY=.*"
+      ];
+    };
+  };
+}

--- a/modules/nixos/linux/atuin.nix
+++ b/modules/nixos/linux/atuin.nix
@@ -1,0 +1,16 @@
+# Atuin sync server (pureintent). Clients use modules/home/cli/atuin.nix.
+#
+# Unique port so we don't fight kolu / tailscale HTTPS on :443.
+# tailscale0 is trusted — no openFirewall.
+{
+  services.atuin = {
+    enable = true;
+    host = "0.0.0.0";
+    port = 18888;
+    openRegistration = true;
+    openFirewall = false;
+    database.createLocally = true;
+  };
+
+  services.postgresql.enable = true;
+}


### PR DESCRIPTION
## Summary

Shell history on these NixOS boxes was easy to lose (bash only flushes `HISTFILE` on a clean exit; SSH drops / killed sessions discard the session). This PR adds **[Atuin](https://atuin.sh/)** end-to-end on the tailnet: a **self-hosted sync server** on pureintent, and **home-manager clients** on pureintent and naiveintent.

### Why Atuin (and not only `history -a`)

| Approach | What it does |
|----------|----------------|
| bash `history -a` | Writes the classic HISTFILE after each command. Fine for one host; weak search; no multi-host. |
| **Atuin** | Records every command into a local SQLite DB (cwd, exit code, host, …), good search UI, optional **encrypted multi-host sync**. |

We self-host so history stays on the tailnet (no Atuin Cloud).

### Architecture

```
naiveintent ──HTTP :18888──► pureintent (services.atuin + PostgreSQL)
pureintent  ──same──────────► pureintent
                 ▲
                 │  WireGuard (Tailscale); no public openFirewall
```

| Piece | Module | Role |
|-------|--------|------|
| **Server** | `modules/nixos/linux/atuin.nix` | NixOS `services.atuin` on pureintent |
| **Client** | `modules/home/cli/atuin.nix` | home-manager `programs.atuin` on pureintent + naiveintent |

**Why home-manager for the client (not NixOS `programs.atuin`)?**  
Interactive bash/zsh on these hosts are owned by home-manager (`~/.bashrc`). NixOS `programs.atuin` installs hooks into `/etc/bashrc`, which HM never sources—so Ctrl-R / up-arrow would not fire. HM `programs.atuin` wires the same shell files that already run starship/direnv/zoxide.

**Why port `18888` (not `:443` / MagicDNS path)?**  
Tailscale HTTPS on `https://pureintent.rooster-blues.ts.net` already reverse-proxies **kolu**. Atuin gets its own port. `tailscale0` is trusted, so we do not open the port on the LAN firewall. Clients use:

`http://pureintent.rooster-blues.ts.net:18888`

HTTP is fine here: the path is already encrypted by Tailscale WireGuard. No extra Tailscale Serve path or TLS terminator.

**Registration:** `openRegistration = true` so you can create the first account; turn it off later if you want a closed server.

### Client settings (pedagogy)

- `auto_sync` / `sync_frequency` — push/pull when logged in; no-op until `atuin login`.
- `sync_address` — self-hosted server above.
- `history_filter` — best-effort skip of common secret-shaped env exports (not a crypto guarantee; still avoid typing secrets into the shell).

### Privacy model (short)

- **Local DB** under the user: plaintext-ish history metadata (like a richer `~/.bash_history`).
- **Sync:** client-side encryption; the server stores ciphertext. Keep `atuin key` private; you need it to enroll another machine.
- **Server trust:** availability + that encrypted blobs exist; not for reading command text if the key is safe.

### After merge / deploy

```bash
just activate pureintent
just activate naiveintent

# once per account (any client):
atuin register   # or: atuin login
atuin key        # save this; required on the other host with login
atuin import auto   # optional: backfill ~/.bash_history
```

Check server: `systemctl status atuin` on pureintent; `curl -sS -o /dev/null -w '%{http_code}\n' http://pureintent.rooster-blues.ts.net:18888/` → `200`.

## Test plan

- [x] `just activate pureintent` — `atuin.service` + PostgreSQL start; listen `0.0.0.0:18888`
- [x] Reachability from naiveintent: HTTP 200 to `pureintent.rooster-blues.ts.net:18888`
- [x] HM client config present (`~/.config/atuin/config.toml` with `sync_address`)
- [x] Starship still works after HM atuin (no `/etc/bashrc` dual-client hacks)
- [ ] Manual: `atuin register` / login + key on second host; `atuin sync`; history visible on both
- [ ] Optional later: set `services.atuin.openRegistration = false` after first account