### PR TITLE
kolu-bot: olai behind GitHub login

### DIFF
--- a/configurations/home/toor@kolu-bot.nix
+++ b/configurations/home/toor@kolu-bot.nix
@@ -1,20 +1,96 @@
-{ pkgs, ... }:
+{ pkgs, flake, config, lib, ... }:
+let
+  githubUsers = [
+    "srid"
+    "shivaraj-bh"
+    "subanesh-swe"
+  ];
+  caddyfile = pkgs.writeText "Caddyfile" ''
+    {
+      admin off
+      auto_https off
+    }
+
+    :8080 {
+      bind 127.0.0.1
+      reverse_proxy 127.0.0.1:${toString config.services.olai.port}
+    }
+  '';
+in
 {
   imports = [
-    ../../modules/home/cli/git.nix
+    (flake.inputs.self + /modules/home/work/opencode.nix)
+    flake.inputs.olai.homeManagerModules.default
   ];
 
   home.username = "toor";
   home.stateVersion = "24.05";
 
-  systemd.user.services.hello = {
-    Unit.Description = "Hello service";
+  # opencode.nix exports JUSPAY_API_KEY via programs.bash.initExtra; that
+  # only ships if HM manages bash (this host is standalone, not NixOS-HM).
+  programs.bash.enable = true;
 
-    Service = {
-      Type = "oneshot";
-      ExecStart = "${pkgs.hello}/bin/hello";
+  programs.ssh = {
+    enable = true;
+    enableDefaultConfig = false;
+    settings."github.com" = {
+      IdentityFile = "~/.ssh/nix-team-olai";
+      IdentitiesOnly = "yes";
     };
+  };
 
+  services.olai = {
+    enable = true;
+    dataDir = "${config.home.homeDirectory}/nix-team-olai";
+    host = "127.0.0.1";
+  };
+
+  age.secrets."oauth2-proxy.env" = {
+    file = flake.inputs.self + /secrets/oauth2-proxy.env.age;
+    path = "${config.home.homeDirectory}/.config/agenix/oauth2-proxy.env";
+  };
+
+  home.packages = [
+    pkgs.caddy
+    pkgs.oauth2-proxy
+  ];
+
+  systemd.user.services.caddy = {
+    Unit = {
+      Description = "Caddy reverse proxy to olai";
+      After = [ "network.target" "olai.service" ];
+      Requires = [ "olai.service" ];
+    };
+    Service = {
+      ExecStart = "${pkgs.caddy}/bin/caddy run --config ${caddyfile} --adapter caddyfile";
+      Restart = "on-failure";
+      RestartSec = "2s";
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+
+  systemd.user.services.oauth2-proxy = {
+    Unit = {
+      Description = "oauth2-proxy (GitHub login)";
+      After = [ "network.target" "caddy.service" "agenix.service" ];
+      Requires = [ "caddy.service" "agenix.service" ];
+    };
+    Service = {
+      EnvironmentFile = config.age.secrets."oauth2-proxy.env".path;
+      ExecStart = lib.concatStringsSep " " ([
+        "${pkgs.oauth2-proxy}/bin/oauth2-proxy"
+        "--provider=github"
+        "--email-domain=*"
+        "--redirect-url=https://kolu-bot.rooster-blues.ts.net/oauth2/callback"
+        "--upstream=http://127.0.0.1:8080"
+        "--http-address=127.0.0.1:4180"
+        "--reverse-proxy=true"
+        "--cookie-secure=true"
+        "--cookie-samesite=lax"
+      ] ++ map (u: "--github-user=${u}") githubUsers);
+      Restart = "on-failure";
+      RestartSec = "2s";
+    };
     Install.WantedBy = [ "default.target" ];
   };
 }

--- a/configurations/home/toor@kolu-bot.nix
+++ b/configurations/home/toor@kolu-bot.nix
@@ -53,6 +53,13 @@ in
     host = "127.0.0.1";
   };
 
+  # systemd user units do not inherit the login PATH; olai's default PATH is
+  # only systemd's bindir, so `git` from programs.git never reaches the
+  # process. Prepend git (and ssh, for git@github.com) explicitly.
+  systemd.user.services.olai.Service.Environment = [
+    "PATH=${lib.makeBinPath [ pkgs.git pkgs.openssh ]}:${config.home.profileDirectory}/bin:/run/wrappers/bin:/run/current-system/sw/bin"
+  ];
+
   age.secrets."oauth2-proxy.env" = {
     file = flake.inputs.self + /secrets/oauth2-proxy.env.age;
     path = "${config.home.homeDirectory}/.config/agenix/oauth2-proxy.env";

--- a/configurations/home/toor@kolu-bot.nix
+++ b/configurations/home/toor@kolu-bot.nix
@@ -30,6 +30,14 @@ in
   # only ships if HM manages bash (this host is standalone, not NixOS-HM).
   programs.bash.enable = true;
 
+  programs.git = {
+    enable = true;
+    settings.user = {
+      name = "olai";
+      email = "olai";
+    };
+  };
+
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;

--- a/configurations/home/toor@kolu-bot.nix
+++ b/configurations/home/toor@kolu-bot.nix
@@ -67,7 +67,6 @@ in
     Unit = {
       Description = "Caddy reverse proxy to olai";
       After = [ "network.target" "olai.service" ];
-      Requires = [ "olai.service" ];
     };
     Service = {
       ExecStart = "${pkgs.caddy}/bin/caddy run --config ${caddyfile} --adapter caddyfile";
@@ -81,7 +80,6 @@ in
     Unit = {
       Description = "oauth2-proxy (GitHub login)";
       After = [ "network.target" "caddy.service" "agenix.service" ];
-      Requires = [ "caddy.service" "agenix.service" ];
     };
     Service = {
       EnvironmentFile = config.age.secrets."oauth2-proxy.env".path;

--- a/docs/CADDY-GITHUB-LOGIN.md
+++ b/docs/CADDY-GITHUB-LOGIN.md
@@ -1,0 +1,260 @@
+# GitHub login in front of Caddy
+
+When Caddy is on the public internet, put **oauth2-proxy** in front of it and
+allow a short list of GitHub usernames. Anyone can hit the URL; only those
+accounts get through.
+
+```
+internet → public HTTPS :443 → oauth2-proxy :4180 → Caddy :8080
+                                 GitHub OAuth
+                                 allow: listed usernames
+```
+
+Caddy keeps serving the site. The proxy is the lock.
+
+Encrypt Client ID, Client Secret, and the cookie secret with **agenix** (same
+pattern as `hedgedoc.env.age`). The username allowlist can live in Nix.
+
+## 1. Create a GitHub OAuth App
+
+1. Open [GitHub Developer settings → OAuth Apps](https://github.com/settings/developers) → **New OAuth App**.
+2. Fill in (use the public URL of the site):
+   - **Application name:** anything
+   - **Homepage URL:** `https://<public-host>/`
+   - **Redirect URI** (under **Redirect URIs**; GitHub used to call this
+     “Authorization callback URL”): `https://<public-host>/oauth2/callback`
+     Leave **Allow wildcard matching** and **Enable Device Flow** unchecked.
+3. Register, then **Generate a new client secret**.
+4. Save **Client ID** and **Client Secret**. The secret is shown once.
+
+You also need the allowed GitHub **usernames** (login names, not emails).
+
+## 2. Encrypt the secrets with agenix
+
+oauth2-proxy reads an env file. Store it as `secrets/oauth2-proxy.env.age`,
+like HedgeDoc’s `hedgedoc.env.age`.
+
+### Recipients
+
+`secrets/secrets.nix` lists who can decrypt. Add the new file next to the
+others, with the same `users ++ systems` keys:
+
+```nix
+"oauth2-proxy.env.age".publicKeys = users ++ systems;
+```
+
+If the machine that will *run* oauth2-proxy is not already a recipient, do this
+once on that host, then add the **public** key to `users` (or `systems`) and
+`just rekey` from `secrets/`:
+
+```bash
+# on the host, if ~/.ssh/agenix does not exist
+ssh-keygen -t ed25519 -f ~/.ssh/agenix -C agenix -N ""
+cat ~/.ssh/agenix.pub
+```
+
+Home-manager decrypts with `~/.ssh/agenix` (`modules/home/agenix.nix`). Without
+that identity in `secrets.nix`, activation cannot decrypt.
+
+### File contents
+
+From the repo, with `~/.ssh/agenix` available:
+
+```bash
+cd secrets
+just edit oauth2-proxy.env.age
+```
+
+Paste:
+
+```
+OAUTH2_PROXY_CLIENT_ID=...
+OAUTH2_PROXY_CLIENT_SECRET=...
+OAUTH2_PROXY_COOKIE_SECRET=...
+```
+
+Cookie secret must be 16, 24, or 32 bytes:
+
+```bash
+openssl rand -base64 32
+```
+
+Commit `oauth2-proxy.env.age` and `secrets.nix`. Never commit the plaintext.
+
+## 3. Run Caddy on localhost only
+
+Caddy should listen on `127.0.0.1:8080` (or any high port), not on the public
+interface. A minimal Caddyfile:
+
+```
+{
+  admin off
+  auto_https off
+}
+
+:8080 {
+  bind 127.0.0.1
+  root * /path/to/site
+  encode gzip
+  file_server
+}
+```
+
+home-manager user service sketch:
+
+```nix
+systemd.user.services.caddy = {
+  Unit = {
+    Description = "Caddy web server";
+    After = [ "network.target" ];
+  };
+  Service = {
+    ExecStart = "${pkgs.caddy}/bin/caddy run --config ${caddyfile} --adapter caddyfile";
+    Restart = "on-failure";
+    RestartSec = "2s";
+  };
+  Install.WantedBy = [ "default.target" ];
+};
+```
+
+## 4. Add oauth2-proxy
+
+- Import `modules/home/agenix.nix`.
+- Decrypt `oauth2-proxy.env.age` to a **literal** path (systemd `EnvironmentFile`
+  does not expand `$XDG_RUNTIME_DIR`).
+- Add `pkgs.oauth2-proxy` and the user service. Replace the public URL and
+  GitHub usernames.
+
+```nix
+{ pkgs, flake, config, ... }:
+{
+  imports = [
+    (flake.inputs.self + /modules/home/agenix.nix)
+  ];
+
+  age.secrets."oauth2-proxy.env" = {
+    file = flake.inputs.self + /secrets/oauth2-proxy.env.age;
+    path = "${config.home.homeDirectory}/.config/agenix/oauth2-proxy.env";
+  };
+
+  home.packages = [
+    pkgs.caddy
+    pkgs.oauth2-proxy
+  ];
+
+  systemd.user.services.oauth2-proxy = {
+    Unit = {
+      Description = "oauth2-proxy (GitHub login)";
+      After = [ "network.target" "caddy.service" ];
+      Requires = [ "caddy.service" ];
+    };
+    Service = {
+      EnvironmentFile = config.age.secrets."oauth2-proxy.env".path;
+      ExecStart = ''
+        ${pkgs.oauth2-proxy}/bin/oauth2-proxy \
+          --provider=github \
+          --email-domain=* \
+          --github-user=alice \
+          --github-user=bob \
+          --github-user=carol \
+          --redirect-url=https://<public-host>/oauth2/callback \
+          --upstream=http://127.0.0.1:8080 \
+          --http-address=127.0.0.1:4180 \
+          --reverse-proxy=true \
+          --cookie-secure=true \
+          --cookie-samesite=lax
+      '';
+      Restart = "on-failure";
+      RestartSec = "2s";
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+}
+```
+
+`--email-domain=*` is required with `--github-user`: GitHub emails are often
+private/`noreply`, so domain checks are useless. The allowlist is the usernames.
+
+Leave Caddy on `:8080`. Point public HTTPS at **4180**, not 8080.
+
+## 5. Activate and check the units
+
+Activate the home config, then:
+
+```bash
+systemctl --user is-active caddy oauth2-proxy
+```
+
+Both should be `active`. If oauth2-proxy fails:
+
+```bash
+journalctl --user -u oauth2-proxy -e -n 50
+```
+
+Typical causes: agenix decrypt failed (`~/.ssh/agenix` missing or not a
+recipient), wrong cookie-secret length, or port 4180 already taken.
+
+## 6. Point public HTTPS at oauth2-proxy
+
+Whatever terminates public TLS must proxy to `127.0.0.1:4180`, not Caddy.
+
+With Tailscale Funnel:
+
+```bash
+sudo tailscale funnel --https=443 off
+sudo tailscale funnel --bg 4180
+tailscale funnel status
+```
+
+Expected:
+
+```text
+https://<public-host> (Funnel on)
+|-- / proxy http://127.0.0.1:4180
+```
+
+Caddy stays local-only. The public URL still works, now behind GitHub login.
+
+If Funnel (or any other reverse proxy) still targets 8080, auth is skipped.
+
+## 7. Check it
+
+In a private browser window:
+
+1. Open `https://<public-host>/`
+2. GitHub login should appear.
+3. An allowed account sees the site.
+4. Any other GitHub account is denied after login.
+
+Local bypass (no GitHub), on the host only:
+
+```bash
+curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8080/
+# 200 — Caddy itself is unauthenticated on localhost
+```
+
+The public URL without a session should redirect to GitHub, not return the site.
+
+## 8. Change who can log in
+
+Edit the `--github-user=` flags and re-activate the home config. No Funnel
+change needed.
+
+Rotate GitHub client secret or cookie secret with:
+
+```bash
+cd secrets
+just edit oauth2-proxy.env.age
+```
+
+Then re-activate the home config. Rotating the cookie secret signs everyone out.
+
+## Notes
+
+- **Why a proxy.** Caddy has no built-in GitHub allowlist. oauth2-proxy is the
+  small, usual layer for this. Caddy security plugins, Authentik, and Keycloak
+  all work and are more moving parts than a few GitHub users need.
+- **Serve vs Funnel.** Tailscale Serve is tailnet-only (no GitHub needed).
+  Funnel is public; that is why this proxy exists.
+- **Linger.** systemd user services only stay up after logout if lingering is
+  on: `sudo loginctl enable-linger $USER`.

--- a/flake.lock
+++ b/flake.lock
@@ -1317,11 +1317,11 @@
         "bun2nix": "bun2nix_3"
       },
       "locked": {
-        "lastModified": 1787347149,
-        "narHash": "sha256-JwLAtInGSltYmSgNiYi08umy53PJWYDhvjpY+ArmjjU=",
+        "lastModified": 1787352710,
+        "narHash": "sha256-AO04uB3wj/63cnGI2IGzCrJHFQ1B2/P91asODgd8jcA=",
         "owner": "juspay",
         "repo": "olai",
-        "rev": "00e0c0af9d999a4ce5c32bddfbc826c497d58a4c",
+        "rev": "9a5de50722d351a550d49a5cf25acb462b81df27",
         "type": "github"
       },
       "original": {

--- a/secrets/juspay-anthropic-api-key.age
+++ b/secrets/juspay-anthropic-api-key.age
@@ -1,9 +1,11 @@
 age-encryption.org/v1
--> ssh-ed25519 96IXNQ xARGTD+HwoFJNUlNqJnPgCFgh21NWpfpG3IgVbnY53M
-th3oAcHh2oFmwrCJCuTk//hfn3ad8RiDfElQ0UYdM4c
--> ssh-ed25519 It7HZQ ADxdXtnMvKfV57VgvO9JQx09Uk4yNFgSnMEr8PX9tUM
-BzIMSHpZ8vfa1PU7cINGMuPZCgamNuyk6Sl9JPz3/TA
--> ssh-ed25519 0mMrRw lBGsIYsWnQBvuOGaxpPMN9FxNIy848ciNEuxOGC8fBc
-GY5+rAUPB97L0SVbWAmT26sfNCul9WytTonyXqFTB8s
---- 1dYxiDNUh3B9KRKw6P8vnZFWYR/uKKef+bRlTB6dUuQ
-o±1¡%?Áﬂ&Ñ÷:$™Ü£ #bﬁ{ù≠*iËZö˛ó5l∑.ÿ”ßã˚i9˛ıÎıjòh⁄Áîò‘
+-> ssh-ed25519 96IXNQ P9UWJ2AvShAs183uNx+AijNgKGUaoEgW3V5HTmsHVnk
+ER2hl6U/zldMQJO2xjrSzv1VedKd9rNVYnIAb/2i6kw
+-> ssh-ed25519 It7HZQ M1nPl5/kInOmtc4/LX1pKnd/v5hH5kfDjl1pH0lCpCA
+wiNdEkvstPYSQGhEbp5lANDj+yhEpMgxigc9cszATVg
+-> ssh-ed25519 0mMrRw wd/MID4xTlt/D+HGBU7iD0LT8IrrxCIykBQprtxt2Bc
+7bTsOnA8uwiN8MmSt8qlBne8FT/h0NlxLAcTVQXz5mA
+-> ssh-ed25519 PK/Wxg 3+iqnIDIlRSQ6BOUx4jSD0+3XYstENWDLGa4KXZKvUo
+gHGC1zgIQi9oEDEbZy0ROQ72uT1xgbYUE+3BnP/JruQ
+--- gS2JZvnfBVZw1Mq6WrtAIjmPg75ebyzMrXZ+wuOJFLI
+kb≤õBV7K>Œ _V<Y˚±∆$)}ÖNô˚é!ÓÇºÀÛ˙ÓÕ÷˛@·€Z.„îdéØ3p`5Yì!

--- a/secrets/oauth2-proxy.env.age
+++ b/secrets/oauth2-proxy.env.age
@@ -1,0 +1,11 @@
+age-encryption.org/v1
+-> ssh-ed25519 96IXNQ KCvfySjSeve2Km5Nixub685qx4XUuIhY18GyheHRBgg
+DARzuaxgDP5Ty/CUa/OT+j/AvI50HU21oQmReXNXpH0
+-> ssh-ed25519 It7HZQ gkb69Bdw/1i6hOhS70AvuQEb9lktWwuBiQFCjEWCslc
+FJutNv9IlwJ21Bg/ODD9Bka8+AfUIL7K/BpEqlFQBG0
+-> ssh-ed25519 0mMrRw uBX74acXbfNRWpMByWeBKCoc5VtpgWe869/MsPKgSQg
+IWg+c9k5KI6KPbuHRMONHLTZ73L6EGHM2roHqe2zJNI
+-> ssh-ed25519 PK/Wxg vJxH/B38cpGd3hoFNFx8WKXqv2nXQWqgQM3gon1o33M
+3GIBV77SnmHgNOnWlgcNVC3xqKsEh/GWMzj9GEnA6+A
+--- Y0CUqG/o2V9TCOl16mPKasynDGdQ06ytxJrcV6anop4
+<ÒN,ˇdZ„X4“∑)˘âÈl5		€ËÍ∂Ez4sk†ÓP  o˚~O@˘ò—˚¿∏Â—ˇK˛¨è0c—˛.ìÂ†âÜ€è[êyËu≤ANA3ﬂèV⁄dQûyÒ˛≈3h~`vrtMp7º<–a‚H/:%2á˚ƒ=Ôf2m∑»oÍ∂”`Ô}´m„Ã¥NπYj7‹”èôb	<˜N≤EáK“Eqñ®hK0≤‘Vf0ê’;ürËb±ˇæU©L√ÅßØ®/~Ër:"ç>È≤˝™1.£êÃÒ`DÇ

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -7,6 +7,8 @@ let
   ];
 
   pureintent = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOKfR7GnwrIVemP/1kna8jboNRegIsaVL6mTi3oXwMdU";
+  # home-manager identity (~/.ssh/agenix), not the host key
+  kolu-bot = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDCpgh8QP6NJFPHzAXdJwtMTqhseD/sqPNm6hQ2Uw9DD toor@kolu-bot";
   systems = [
     pureintent
   ];
@@ -18,7 +20,8 @@ in
   "pureintent-basic-auth.age".publicKeys = users ++ systems;
   "gmail-app-password.age".publicKeys = users ++ systems;
   "hackage-password.age".publicKeys = users ++ systems;
-  "juspay-anthropic-api-key.age".publicKeys = users ++ systems;
+  "juspay-anthropic-api-key.age".publicKeys = users ++ systems ++ [ kolu-bot ];
+  "oauth2-proxy.env.age".publicKeys = users ++ systems ++ [ kolu-bot ];
   "beszel-agent-key.age".publicKeys = users ++ systems;
   "vira-github-webhook-secret.age".publicKeys = users ++ systems;
   "vira-github-private-key.age".publicKeys = users ++ systems;


### PR DESCRIPTION
## What this is

`kolu-bot` is not a NixOS host in this flake. It is a **standalone home-manager** config (`configurations/home/toor@kolu-bot.nix`) for user `toor`. Activate it with:

```bash
nix run . toor@kolu-bot
```

The machine publishes a public HTTPS URL via Tailscale Funnel. Funnel has no allowlist — anyone on the internet can hit the hostname — so the app has to authenticate. This PR puts **GitHub OAuth** in front of **olai**, with Caddy in the middle as the reverse proxy Funnel already talked to.

## Request path

```
internet
  → Funnel :443          (public TLS, Tailscale)
  → oauth2-proxy :4180   (GitHub login + username allowlist)
  → Caddy :8080          (reverse_proxy, loopback only)
  → olai :7714           (outliner, loopback only)
```

Why three processes instead of one:

- **Funnel** terminates public HTTPS. It only knows a port. Today that port is oauth2-proxy (`4180`), not Caddy and not olai.
- **oauth2-proxy** is the lock. Unauthenticated requests get a GitHub sign-in page. After login, only listed GitHub usernames pass. Client ID / secret / cookie secret live in agenix, not in Nix.
- **Caddy** is the local reverse proxy Funnel used to point at. It binds `127.0.0.1:8080` and `reverse_proxy`s to olai. Keeping Caddy means Funnel’s upstream (via oauth2-proxy) stays `:8080` even if olai’s port changes.
- **olai** has no auth of its own (`host = 127.0.0.1`). `dataDir` is `~/nix-team-olai`. Default listen port is `7714` (“olai” on a phone keypad). Caddy reads `config.services.olai.port` so the two cannot drift.

A browser that is not logged in never talks to olai. Loopback services are not on Funnel.

## GitHub login, in short

oauth2-proxy is configured as `provider=github` with `--github-user` for:

- `srid`
- `shivaraj-bh`
- `subanesh-swe`

`--email-domain=*` is required with `--github-user`: GitHub emails are often private/`noreply`, so domain checks are useless. The allowlist is usernames.

The OAuth App’s **Redirect URI** (GitHub’s current name for the callback) is:

`https://kolu-bot.rooster-blues.ts.net/oauth2/callback`

Walkthrough for repeating this pattern on another host: [`docs/CADDY-GITHUB-LOGIN.md`](docs/CADDY-GITHUB-LOGIN.md).

## Secrets (agenix)

Home-manager decrypts with **`~/.ssh/agenix`**, not the host SSH key. That public key is named `kolu-bot` in `secrets/secrets.nix` and is a recipient of **only** the secrets this machine needs:

| File | Why this host |
| --- | --- |
| `oauth2-proxy.env.age` | GitHub Client ID/secret + cookie secret |
| `juspay-anthropic-api-key.age` | `JUSPAY_API_KEY` for opencode |

It is **not** on gmail, CI tokens, HedgeDoc, etc. Rekeying one file does not grant the box the rest of the vault.

`oauth2-proxy.env.age` must be **git-tracked**. Nix flakes only copy tracked files; an untracked `.age` builds a store path that does not exist, and `agenix.service` fails at decrypt.

On this host, `programs.bash.enable` is on so `modules/home/work/opencode.nix` can export `JUSPAY_API_KEY` from the decrypted file in `bashrc`. Standalone home-manager does not inherit NixOS’s bash module.

## GitHub SSH for the outlines repo

`git clone git@github.com:juspay/nix-team-olai.git` uses `~/.ssh/nix-team-olai` via `programs.ssh.settings."github.com"`. SSH only sees the hostname, not the repo path, so **every** `git@github.com` connection on this box uses that identity (`IdentitiesOnly yes`). That is appropriate if the key is a deploy key for this repo.

## Deploy notes

- `nix run . toor@kolu-bot`
- Funnel should stay on **4180** (oauth2-proxy). Pointing it at 8080 or 7714 skips GitHub login.
- `toor` does not linger; user services run while a session exists.