### PR TITLE
simplify: dedup host configs, drop redundant settings

### DIFF
--- a/configurations/darwin/infinitude-macos/default.nix
+++ b/configurations/darwin/infinitude-macos/default.nix
@@ -1,5 +1,5 @@
 # Configuration for my Mac CI VM
-{ flake, pkgs, ... }:
+{ flake, ... }:
 
 let
   inherit (flake) inputs;

--- a/configurations/home/srid@zest.nix
+++ b/configurations/home/srid@zest.nix
@@ -41,7 +41,6 @@ in
 
   home.packages = [
     inputs.disc-scrape.packages.${pkgs.stdenv.hostPlatform.system}.default
-    pkgs.zellij-one
     pkgs.twitter-convert
     pkgs.python3
     pkgs.uv

--- a/configurations/nixos/myolai/olai.nix
+++ b/configurations/nixos/myolai/olai.nix
@@ -1,5 +1,5 @@
 # olai home-manager config for the myolai container (its only user).
-{ flake, config, pkgs, ... }:
+{ flake, config, ... }:
 
 let
   inherit (flake) inputs;

--- a/configurations/nixos/naiveintent/configuration.nix
+++ b/configurations/nixos/naiveintent/configuration.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, pkgs, ... }:
+{ flake, pkgs, ... }:
 
 {
   imports =
@@ -26,9 +26,6 @@
 
   # Enable networking
   networking.networkmanager.enable = true;
-
-  # Set your time zone.
-  time.timeZone = "America/New_York";
 
   # Select internationalisation properties.
   i18n.defaultLocale = "en_US.UTF-8";
@@ -81,15 +78,11 @@
   # Enable touchpad support (enabled default in most desktopManager).
   # services.xserver.libinput.enable = true;
 
-  # Define a user account. Don't forget to set a password with ‘passwd’.
-  users.users.srid = {
-    isNormalUser = true;
-    description = "Sridhar Ratnakumar";
-    extraGroups = [ "networkmanager" "wheel" ];
-    packages = with pkgs; [
-      kdePackages.kate
-    #  thunderbird
-    ];
+  # isNormalUser / extraGroups / ssh keys come from
+  # modules/nixos/shared/primary-as-admin.nix.
+  users.users.${flake.config.me.username} = {
+    description = flake.config.me.fullname;
+    packages = [ pkgs.kdePackages.kate ];
   };
 
   # Install firefox.
@@ -99,11 +92,8 @@
   programs._1password.enable = true;
   programs._1password-gui = {
     enable = true;
-    polkitPolicyOwners = [ "srid" ];
+    polkitPolicyOwners = [ flake.config.me.username ];
   };
-
-  # Allow unfree packages
-  nixpkgs.config.allowUnfree = true;
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
@@ -124,9 +114,6 @@
   # };
 
   # List services that you want to enable:
-
-  # Enable the OpenSSH daemon.
-  services.openssh.enable = true;
 
   # Open ports in the firewall.
   # networking.firewall.allowedTCPPorts = [ ... ];

--- a/configurations/nixos/naiveintent/default.nix
+++ b/configurations/nixos/naiveintent/default.nix
@@ -1,4 +1,4 @@
-{ config, flake, lib, pkgs, ... }:
+{ flake, pkgs, ... }:
 
 let
   inherit (flake) inputs;
@@ -7,23 +7,11 @@ let
 in
 {
   nixos-unified.sshTarget = "srid@naiveintent";
-  nixos-unified.localPrivilegeMode = "sudo-nixos-rebuild";
-
-  security.sudo.extraRules = [
-    {
-      users = [ flake.config.me.username ];
-      commands = [
-        {
-          command = "/run/current-system/sw/bin/nixos-rebuild switch *";
-          options = [ "NOPASSWD" ];
-        }
-      ];
-    }
-  ];
 
   imports = [
     self.nixosModules.default
     ./configuration.nix
+    (self + /modules/nixos/linux/my-workstation.nix)
     # pu / xyne-boxes + juspay-run (needs jumphost SOCKS5 from juspay.nix)
     (self + /modules/nixos/linux/devbox.nix)
     (self + /modules/nixos/linux/gc.nix)
@@ -32,16 +20,8 @@ in
     (self + /modules/nixos/linux/kill-audit.nix)
   ];
 
-  users.users.${flake.config.me.username}.linger = true;
   home-manager.sharedModules = [
     "${homeMod}/gui/1password.nix"
-    "${homeMod}/cli/odu.nix"
-    "${homeMod}/cli/atuin.nix"
-    "${homeMod}/claude-code"
-    # Jump host SOCKS5 (jumphost-nix) — required by pu / juspay-run
-    "${homeMod}/work/juspay.nix"
-    # Juspay opencode config (juspay-ai) + llm-agents package
-    "${homeMod}/work/opencode.nix"
     # Juspay pi (same as nix run github:juspay/AI#pi-juspay-oneclick)
     "${homeMod}/work/pi.nix"
     # myolai still serves the Vault outlines; this is the olai repo's own docs.
@@ -53,43 +33,19 @@ in
         push = "auto";
       };
     })
-    "${homeMod}/nix/gc.nix"
   ];
-
-  nix.settings = {
-    sandbox = "relaxed";
-    extra-experimental-features = [ "impure-derivations" "ca-derivations" ];
-  };
-  # GC: system generations via modules/nixos/linux/gc.nix (root-owned);
-  # user profile via home-manager (modules/home/nix/gc.nix).
 
   zramSwap.enable = true;
   swapDevices = [{
     device = "/var/lib/swapfile";
-    size = 64 * 1024; # 32GB in megabytes
+    size = 64 * 1024; # 64GB in megabytes
   }];
 
-  services.openssh.enable = true;
-  services.tailscale.enable = true;
-  # tailscaled installs its rules via iptables-nft, which live in a different
-  # table from the nftables firewall that incus requires. Adding tailscale0 here
-  # gets it into the nftables trusted-interfaces set too.
-  networking.firewall.trustedInterfaces = [ "tailscale0" ];
-  networking.firewall.allowedTCPPorts = [
-    80
-    443
-    7692
-  ];
-
-  programs.nix-ld.enable = true; # for claude code
+  networking.firewall.allowedTCPPorts = [ 7692 ];
 
   # HACK: system package so kolu MCP works on remote hosts (PATH / nix-ld), not the
   # full services.kolu user service (see modules/home/services/kolu.nix on pureintent).
   environment.systemPackages = [
     inputs.kolu.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
-
-  # Workaround the annoying `Failed to start Network Manager Wait Online` error on switch.
-  # https://github.com/NixOS/nixpkgs/issues/180175
-  systemd.services.NetworkManager-wait-online.enable = false;
 }

--- a/configurations/nixos/pureintent/configuration.nix
+++ b/configurations/nixos/pureintent/configuration.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, flake, pkgs, ... }:
+{ flake, pkgs, ... }:
 
 {
   imports =
@@ -79,18 +79,12 @@
   # Enable touchpad support (enabled default in most desktopManager).
   # services.xserver.libinput.enable = true;
 
-  # Define a user account. Don't forget to set a password with ‘passwd’.
-  users.users.${flake.config.me.username} = {
-    isNormalUser = true;
-    description = flake.config.me.fullname;
-    extraGroups = [ "networkmanager" "wheel" ];
-  };
+  # isNormalUser / extraGroups / ssh keys come from
+  # modules/nixos/shared/primary-as-admin.nix.
+  users.users.${flake.config.me.username}.description = flake.config.me.fullname;
 
   # Install firefox.
   programs.firefox.enable = true;
-
-  # Allow unfree packages
-  nixpkgs.config.allowUnfree = true;
 
   # The NixOS options manual is rarely consulted locally (options are searched
   # online), but generating it evaluates the doc string of every option — a
@@ -115,8 +109,6 @@
 
   # List services that you want to enable:
 
-  # Enable the OpenSSH daemon.
-  services.openssh.enable = true;
   # TTS: `spd-say "hello"` or `spd-say -l fr "bonjour"`
   # Volume: `wpctl set-volume @DEFAULT_AUDIO_SINK@ 50%` (or 5%+/5%-)
   services.speechd.enable = true;

--- a/configurations/nixos/pureintent/default.nix
+++ b/configurations/nixos/pureintent/default.nix
@@ -1,4 +1,4 @@
-{ config, flake, lib, ... }:
+{ flake, lib, ... }:
 
 let
   inherit (flake) inputs;
@@ -12,23 +12,11 @@ in
 {
   nixos-unified.sshTarget = "srid@pureintent";
   # nixos-unified.sshTarget = "srid@192.168.2.134";
-  nixos-unified.localPrivilegeMode = "sudo-nixos-rebuild";
-
-  security.sudo.extraRules = [
-    {
-      users = [ flake.config.me.username ];
-      commands = [
-        {
-          command = "/run/current-system/sw/bin/nixos-rebuild switch *";
-          options = [ "NOPASSWD" ];
-        }
-      ];
-    }
-  ];
 
   imports = [
     self.nixosModules.default
     ./configuration.nix
+    (self + /modules/nixos/linux/my-workstation.nix)
     (self + /modules/nixos/linux/juspay-run.nix)
     ./kolu-dev.nix
     (self + /modules/nixos/linux/beszel.nix)
@@ -37,15 +25,9 @@ in
     (self + /modules/nixos/linux/atuin.nix)
   ];
 
-  users.users.${flake.config.me.username}.linger = true;
   home-manager.sharedModules = [
     "${homeMod}/cli/ssh-agent-forwarding.nix"
     "${homeMod}/cli/controlpersist.nix"
-    "${homeMod}/cli/odu.nix"
-    "${homeMod}/cli/atuin.nix"
-    "${homeMod}/claude-code"
-    "${homeMod}/work/juspay.nix"
-    "${homeMod}/work/opencode.nix"
     "${homeMod}/services/kolu.nix"
     "${homeMod}/services/drishti"
     {
@@ -66,16 +48,7 @@ in
     # Remote builders
     "${homeMod}/nix/buildMachines"
     "${homeMod}/nix/buildMachines/sincereintent.nix"
-
-    "${homeMod}/nix/gc.nix"
   ];
-
-  nix.settings = {
-    sandbox = "relaxed";
-    extra-experimental-features = [ "impure-derivations" "ca-derivations" ];
-  };
-  # GC: system generations via modules/nixos/linux/gc.nix (root-owned);
-  # user profile via home-manager (modules/home/nix/gc.nix).
 
   # Prefer compressed in-RAM swap so page faults under build + Claude fleet
   # load become decompression instead of QLC disk I/O thrashing.
@@ -88,20 +61,6 @@ in
   # DRAM-less QLC drive is what stalls the box; better to OOM-kill the runaway
   # process (earlyoom below) than thrash.
   swapDevices = lib.mkForce [ ];
-
-  services.openssh.enable = true;
-  services.tailscale.enable = true;
-  networking.firewall.trustedInterfaces = [ "tailscale0" ];
-  networking.firewall.allowedTCPPorts = [
-    80
-    443
-  ];
-
-  programs.nix-ld.enable = true; # for vscode server
-
-  # Workaround the annoying `Failed to start Network Manager Wait Online` error on switch.
-  # https://github.com/NixOS/nixpkgs/issues/180175
-  systemd.services.NetworkManager-wait-online.enable = false;
 
   # Workaround `nixos-rebuild switch` hanging at "reloading the following units:
   # dbus-broker.service". The reload step stalls (broker has long-lived clients

--- a/configurations/nixos/pureintent/kolu-dev.nix
+++ b/configurations/nixos/pureintent/kolu-dev.nix
@@ -1,12 +1,12 @@
 # Host-side bits for kolu development on pureintent.
-{ flake, ... }:
+{ ... }:
 
 {
   # Dedicated account for kolu end-to-end remote-terminal tests.
   # Authorize srid (same machine) to `ssh kolu-e2e-remote@localhost` with his key.
   users.users.kolu-e2e-remote = {
     isNormalUser = true;
-    openssh.authorizedKeys.keys = [ 
+    openssh.authorizedKeys.keys = [
       # pureintent srid
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEnWriRB3c/G+O4/N5ALnOQBdBTp9LeGC6HNYTZCCGS2 srid@pureintent"
     ];

--- a/flake.nix
+++ b/flake.nix
@@ -69,10 +69,9 @@
   outputs = inputs@{ self, ... }:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
-      imports = (with builtins;
-        map
-          (fn: ./modules/flake-parts/${fn})
-          (attrNames (readDir ./modules/flake-parts)));
+      imports = map
+        (fn: ./modules/flake-parts/${fn})
+        (builtins.attrNames (builtins.readDir ./modules/flake-parts));
 
       perSystem = { lib, system, ... }: {
         # Make our overlay available to the devShell

--- a/modules/home/claude-code/default.nix
+++ b/modules/home/claude-code/default.nix
@@ -1,4 +1,4 @@
-{ flake, pkgs, ... }:
+{ pkgs, ... }:
 {
   home.packages = [
     # flake.inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code

--- a/modules/home/cli/controlpersist.nix
+++ b/modules/home/cli/controlpersist.nix
@@ -1,21 +1,9 @@
-{ ... }:
+{ lib, ... }:
 {
   programs.ssh.enableDefaultConfig = false;
-  programs.ssh.settings = {
-    pureintent = {
-      ControlMaster = "auto";
-      ControlPath = "~/.ssh/sockets/%r@%h-%p";
-      ControlPersist = "900";
-    };
-    sincereintent = {
-      ControlMaster = "auto";
-      ControlPath = "~/.ssh/sockets/%r@%h-%p";
-      ControlPersist = "900";
-    };
-    zest = {
-      ControlMaster = "auto";
-      ControlPath = "~/.ssh/sockets/%r@%h-%p";
-      ControlPersist = "900";
-    };
-  };
+  programs.ssh.settings = lib.genAttrs [ "pureintent" "sincereintent" "zest" ] (_: {
+    ControlMaster = "auto";
+    ControlPath = "~/.ssh/sockets/%r@%h-%p";
+    ControlPersist = "900";
+  });
 }

--- a/modules/home/cli/direnv.nix
+++ b/modules/home/cli/direnv.nix
@@ -1,14 +1,9 @@
-{ config, pkgs, lib, ... }:
+{ ... }:
 
 {
   programs.direnv = {
     enable = true;
-    nix-direnv = {
-      enable = true;
-      # Until https://github.com/nix-community/home-manager/pull/5773
-      package = lib.mkIf (config.nix.package != null)
-        (pkgs.nix-direnv.override { nix = config.nix.package; });
-    };
+    nix-direnv.enable = true;
     config.global = {
       hide_env_diff = true;
     };

--- a/modules/home/cli/ssh-agent-forwarding.nix
+++ b/modules/home/cli/ssh-agent-forwarding.nix
@@ -14,7 +14,7 @@
 #
 # Reference: https://stackoverflow.com/a/23187030
 
-{ config, lib, pkgs, ... }:
+{ config, ... }:
 
 let
   sshAuthSockLink = "${config.home.homeDirectory}/.ssh/ssh_auth_sock";

--- a/modules/home/cli/terminal.nix
+++ b/modules/home/cli/terminal.nix
@@ -48,7 +48,9 @@ in
     hledger
 
     gnupg
-    # Temporarily disabled: pulls in ffmpeg-full which fails to build (kvazaar test failures)
+    # Disabled: the old ffmpeg-full build failure is fixed (it now uses plain
+    # ffmpeg), but that is still a ~1GiB closure on every host for a tool
+    # that's only occasionally needed. Run it with `nix run .#compress-video`.
     # compress-video
   ];
 

--- a/modules/home/cli/terminal.nix
+++ b/modules/home/cli/terminal.nix
@@ -24,7 +24,6 @@ in
     # Useful for Nix development
     ci
     nixpkgs-fmt
-    just
     watchexec
     fswatch
 

--- a/modules/home/gui/1password.nix
+++ b/modules/home/gui/1password.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 {
   home.packages = [ pkgs._1password-cli ];
 
@@ -15,12 +15,8 @@
           else
             "~/.1password/agent.sock";
       };
-      pureintent = {
-        ForwardAgent = true;
-      };
-      sincereintent = {
-        ForwardAgent = true;
-      };
-    };
+    } // lib.genAttrs [ "pureintent" "sincereintent" ] (_: {
+      ForwardAgent = true;
+    });
   };
 }

--- a/modules/home/nix/buildMachines/pureintent.nix
+++ b/modules/home/nix/buildMachines/pureintent.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ config, ... }:
 {
   # Configure remote building to pureintent (NixOS x86_64-linux builder)
   nix.buildMachines = [
@@ -13,7 +13,7 @@
       supportedFeatures = [ "nixos-test" "benchmark" "big-parallel" "kvm" ];
       mandatoryFeatures = [ ];
 
-      sshKey = "/Users/srid/.ssh/nix-remote-builder";
+      sshKey = "${config.home.homeDirectory}/.ssh/nix-remote-builder";
 
       # Run on the remote machine:
       # , base64 -w0 /etc/ssh/ssh_host_ed25519_key.pub

--- a/modules/home/nix/buildMachines/sincereintent.nix
+++ b/modules/home/nix/buildMachines/sincereintent.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ config, ... }:
 {
   # Configure remote building to sincereintent (macOS builder)
   nix.buildMachines = [
@@ -14,8 +14,7 @@
       supportedFeatures = [ "benchmark" "big-parallel" ];
       mandatoryFeatures = [ ];
 
-      # We need this!
-      sshKey = "/home/srid/.ssh/nix-remote-builder";
+      sshKey = "${config.home.homeDirectory}/.ssh/nix-remote-builder";
 
       # This too!
       # Run on the remote machine:

--- a/modules/home/services/kolu.nix
+++ b/modules/home/services/kolu.nix
@@ -1,4 +1,4 @@
-{ flake, config, pkgs, ... }:
+{ flake, pkgs, ... }:
 
 let
   inherit (flake) inputs;

--- a/modules/home/work/juspay-run.nix
+++ b/modules/home/work/juspay-run.nix
@@ -1,13 +1,10 @@
 # `juspay-run` over the jumphost SOCKS5. Home-manager so it works on zest
 # (darwin) as well as the Linux hosts that import juspay.nix.
-{ config, pkgs, lib, ... }:
+{ config, flake, pkgs, lib, ... }:
 
 let
   socksPort = config.programs.jumphost.socks5Proxy.port;
-  # Hostname `pu` is not reachable through the jumphost SOCKS. Same pin as
-  # modules/nixos/linux/devbox.nix; xyne-boxes defaults PU_HOST to `pu`.
-  # https://github.com/juspay/xyne-boxes/pull/14#issuecomment-4918563982
-  puHost = "10.10.68.56";
+  inherit (import (flake.inputs.self + /modules/work/pu.nix)) proxyEnv;
   # netcat-openbsd is broken on Darwin; Apple nc speaks the same -X 5 -x.
   socksNc =
     if pkgs.stdenv.hostPlatform.isDarwin then "/usr/bin/nc"
@@ -51,10 +48,7 @@ in
         fi
         exit 1
       fi
-      export ALL_PROXY=socks5://127.0.0.1:${toString socksPort}
-      export HTTPS_PROXY=socks5://127.0.0.1:${toString socksPort}
-      export HTTP_PROXY=socks5://127.0.0.1:${toString socksPort}
-      export PU_HOST=${puHost}
+      ${proxyEnv socksPort}
       # Apple /usr/bin/ssh is SIP-protected and ignores DYLD_INSERT_LIBRARIES.
       # Nix OpenSSH is the one proxychains can actually hook.
       export PATH="${lib.getBin pkgs.openssh}/bin:$PATH"

--- a/modules/home/work/pi.nix
+++ b/modules/home/work/pi.nix
@@ -12,17 +12,10 @@ in
     (pkgs.writeShellApplication {
       name = "pi";
       text = ''
-        has_model=0
-        for arg in "$@"; do
-          if [ "$arg" = "--model" ]; then
-            has_model=1
-            break
-          fi
-        done
-        if [ "$has_model" -eq 0 ]; then
-          exec ${lib.getExe pi} --model litellm/kimi-k3 "$@"
-        fi
-        exec ${lib.getExe pi} "$@"
+        case " $* " in
+          *" --model "*) exec ${lib.getExe pi} "$@" ;;
+          *) exec ${lib.getExe pi} --model litellm/kimi-k3 "$@" ;;
+        esac
       '';
     })
   ];

--- a/modules/home/work/pi.nix
+++ b/modules/home/work/pi.nix
@@ -12,10 +12,14 @@ in
     (pkgs.writeShellApplication {
       name = "pi";
       text = ''
-        case " $* " in
-          *" --model "*) exec ${lib.getExe pi} "$@" ;;
-          *) exec ${lib.getExe pi} --model litellm/kimi-k3 "$@" ;;
-        esac
+        # Token-exact: an argument that merely *contains* "--model" must not
+        # count as the user having passed the flag.
+        for arg in "$@"; do
+          if [ "$arg" = "--model" ]; then
+            exec ${lib.getExe pi} "$@"
+          fi
+        done
+        exec ${lib.getExe pi} --model litellm/kimi-k3 "$@"
       '';
     })
   ];

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,5 +1,5 @@
 # Configuration common to all Linux systems
-{ flake, lib, ... }:
+{ flake, ... }:
 
 let
   inherit (flake) config inputs;
@@ -8,7 +8,7 @@ in
 {
   imports = [
     {
-      users.users.${config.me.username}.isNormalUser = lib.mkDefault true;
+      # isNormalUser comes from shared/primary-as-admin.nix.
       home-manager.useGlobalPkgs = true;
       home-manager.backupFileExtension = "hm-backup";
       home-manager.users.${config.me.username} = { };

--- a/modules/nixos/linux/devbox.nix
+++ b/modules/nixos/linux/devbox.nix
@@ -6,14 +6,10 @@ let
   socksPort = config.home-manager.users.${flake.config.me.username}.programs.jumphost.socks5Proxy.port;
   proxychainsBin = "${config.programs.proxychains.package}/bin/proxychains4";
   xbPkg = flake.inputs.xyne-boxes.packages.${pkgs.stdenv.hostPlatform.system}.default;
-  # Context: https://github.com/juspay/xyne-boxes/pull/14#issuecomment-4918563982
-  puHost = "10.10.68.56";
+  inherit (import (flake.inputs.self + /modules/work/pu.nix)) proxyEnv;
 
   wrap = name: pkgs.writeShellScriptBin name ''
-    export ALL_PROXY=socks5://127.0.0.1:${toString socksPort}
-    export HTTPS_PROXY=socks5://127.0.0.1:${toString socksPort}
-    export HTTP_PROXY=socks5://127.0.0.1:${toString socksPort}
-    export PU_HOST=${puHost}
+    ${proxyEnv socksPort}
     exec ${proxychainsBin} ${xbPkg}/bin/${name} "$@"
   '';
 in

--- a/modules/nixos/linux/kill-audit.nix
+++ b/modules/nixos/linux/kill-audit.nix
@@ -7,13 +7,22 @@
 {
   security.auditd.enable = true;
   security.audit.enable = true;
-  security.audit.rules = [
-    "-a always,exit -F arch=b64 -S kill -F a1=15 -k sigterm-audit"
-    "-a always,exit -F arch=b64 -S kill -F a1=9 -k sigkill-audit"
-    # Filter on the signal (a2 here, a1 for kill) — unfiltered, this records
-    # every Go-runtime SIGURG preemption from tailscaled/incusd and floods
-    # /var/log/audit.
-    "-a always,exit -F arch=b64 -S tkill,tgkill,pidfd_send_signal -F a2=15 -k sig-audit"
-    "-a always,exit -F arch=b64 -S tkill,tgkill,pidfd_send_signal -F a2=9 -k sig-audit"
-  ];
+  security.audit.rules =
+    let
+      # Filter on the signal, else this records every SIGURG the Go runtime
+      # sends for async preemption (tailscaled, incusd) and floods the log.
+      #
+      # The signal's argument index differs per syscall, so the rules have to
+      # be split:
+      #   kill(pid, sig)                            -> a1
+      #   tkill(tid, sig)                           -> a1
+      #   pidfd_send_signal(pidfd, sig, info, flags) -> a1
+      #   tgkill(tgid, tid, sig)                    -> a2
+      rules = sig: key: [
+        "-a always,exit -F arch=b64 -S kill -F a1=${toString sig} -k ${key}"
+        "-a always,exit -F arch=b64 -S tkill,pidfd_send_signal -F a1=${toString sig} -k sig-audit"
+        "-a always,exit -F arch=b64 -S tgkill -F a2=${toString sig} -k sig-audit"
+      ];
+    in
+    rules 15 "sigterm-audit" ++ rules 9 "sigkill-audit";
 }

--- a/modules/nixos/linux/kill-audit.nix
+++ b/modules/nixos/linux/kill-audit.nix
@@ -10,6 +10,10 @@
   security.audit.rules = [
     "-a always,exit -F arch=b64 -S kill -F a1=15 -k sigterm-audit"
     "-a always,exit -F arch=b64 -S kill -F a1=9 -k sigkill-audit"
-    "-a always,exit -F arch=b64 -S tkill,tgkill,pidfd_send_signal -k sig-audit"
+    # Filter on the signal (a2 here, a1 for kill) — unfiltered, this records
+    # every Go-runtime SIGURG preemption from tailscaled/incusd and floods
+    # /var/log/audit.
+    "-a always,exit -F arch=b64 -S tkill,tgkill,pidfd_send_signal -F a2=15 -k sig-audit"
+    "-a always,exit -F arch=b64 -S tkill,tgkill,pidfd_send_signal -F a2=9 -k sig-audit"
   ];
 }

--- a/modules/nixos/linux/my-workstation.nix
+++ b/modules/nixos/linux/my-workstation.nix
@@ -1,0 +1,66 @@
+# Shared profile for my deployed Linux workstations (pureintent, naiveintent).
+#
+# These two hosts are deployed the same way (`just activate` over SSH, as a
+# non-root user) and run the same working set. Everything that was identical
+# in both host files lives here; the host files keep only what genuinely
+# differs (sshTarget, hostname, swap policy, extra ports/modules).
+{ flake, ... }:
+let
+  inherit (flake) config inputs;
+  inherit (inputs) self;
+  homeMod = self + /modules/home;
+in
+{
+  # Deploying over SSH as an unprivileged user needs both halves: the mode
+  # tells nixos-unified to shell out to sudo, and the sudo rule makes that
+  # non-interactive. Keep them together — one without the other makes
+  # `just activate` prompt or fail.
+  nixos-unified.localPrivilegeMode = "sudo-nixos-rebuild";
+  security.sudo.extraRules = [
+    {
+      users = [ config.me.username ];
+      commands = [
+        {
+          command = "/run/current-system/sw/bin/nixos-rebuild switch *";
+          options = [ "NOPASSWD" ];
+        }
+      ];
+    }
+  ];
+
+  # home-manager user services (kolu, drishti, olai, …) must start at boot
+  # without a login session.
+  users.users.${config.me.username}.linger = true;
+
+  nix.settings = {
+    sandbox = "relaxed";
+    extra-experimental-features = [ "impure-derivations" "ca-derivations" ];
+  };
+  # GC: system generations via modules/nixos/linux/gc.nix (root-owned);
+  # user profile via home-manager (modules/home/nix/gc.nix).
+
+  services.openssh.enable = true;
+  services.tailscale.enable = true;
+  # tailscaled installs its rules via iptables-nft, which live in a different
+  # table from the nftables firewall that incus requires. Adding tailscale0 here
+  # gets it into the nftables trusted-interfaces set too.
+  networking.firewall.trustedInterfaces = [ "tailscale0" ];
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
+
+  programs.nix-ld.enable = true; # for claude code / vscode server
+
+  # Workaround the annoying `Failed to start Network Manager Wait Online` error on switch.
+  # https://github.com/NixOS/nixpkgs/issues/180175
+  systemd.services.NetworkManager-wait-online.enable = false;
+
+  home-manager.sharedModules = [
+    "${homeMod}/cli/odu.nix"
+    "${homeMod}/cli/atuin.nix"
+    "${homeMod}/claude-code"
+    # Jump host SOCKS5 (jumphost-nix) — required by pu / juspay-run
+    "${homeMod}/work/juspay.nix"
+    # Juspay opencode config (juspay-ai) + llm-agents package
+    "${homeMod}/work/opencode.nix"
+    "${homeMod}/nix/gc.nix"
+  ];
+}

--- a/modules/nixos/shared/primary-as-admin.nix
+++ b/modules/nixos/shared/primary-as-admin.nix
@@ -1,23 +1,21 @@
-# Make flake.config.peope.myself the admin of the machine
+# Make flake.config.me the admin of the machine
 { flake, pkgs, lib, ... }:
 
 {
-  # Login via SSH with mmy SSH key
+  # Login via SSH with my SSH key
   users.users =
     let
       me = flake.config.me;
-      myKeys = [
-        me.sshKey
-      ];
+      isLinux = pkgs.stdenv.hostPlatform.isLinux;
+      myKeys = [ me.sshKey ];
     in
     {
       root.openssh.authorizedKeys.keys = myKeys;
       ${me.username} = {
         openssh.authorizedKeys.keys = myKeys;
-        shell = pkgs.zsh;
-      } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        shell = if isLinux then pkgs.bash else pkgs.zsh;
+      } // lib.optionalAttrs isLinux {
         isNormalUser = lib.mkDefault true;
-        shell = pkgs.bash;
         extraGroups = [ "networkmanager" "wheel" ];
       };
     };

--- a/modules/work/pu.nix
+++ b/modules/work/pu.nix
@@ -1,0 +1,19 @@
+# Shared constants for the Juspay `pu` / xyne-boxes tooling.
+#
+# Consumed by both layers: modules/home/work/juspay-run.nix (home-manager) and
+# modules/nixos/linux/devbox.nix (NixOS). Plain attrs, not a module — `import`
+# it rather than adding it to `imports`.
+rec {
+  # Hostname `pu` is not reachable through the jumphost SOCKS; xyne-boxes
+  # defaults PU_HOST to `pu`, so pin the IP.
+  # https://github.com/juspay/xyne-boxes/pull/14#issuecomment-4918563982
+  puHost = "10.10.68.56";
+
+  # The env every pu/xyne-boxes invocation needs in front of it.
+  proxyEnv = socksPort: ''
+    export ALL_PROXY=socks5://127.0.0.1:${toString socksPort}
+    export HTTPS_PROXY=socks5://127.0.0.1:${toString socksPort}
+    export HTTP_PROXY=socks5://127.0.0.1:${toString socksPort}
+    export PU_HOST=${puHost}
+  '';
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -4,31 +4,12 @@ let
   inherit (flake) inputs;
   inherit (inputs) self;
   packages = self + /packages;
-
 in
 self: super:
-let
-  # Auto-import all packages from the packages directory
-  # TODO: Upstream this to nixos0-unified?
-  entries = builtins.readDir packages;
 
-  # Convert directory entries to package definitions
-  makePackage = name: type:
-    let
-      # Remove .nix extension for package name
-      pkgName =
-        if type == "regular" && builtins.match ".*\\.nix$" name != null
-        then builtins.replaceStrings [ ".nix" ] [ "" ] name
-        else name;
-    in
-    {
-      name = pkgName;
-      value = self.callPackage (packages + "/${name}") { };
-    };
-
-  # Import everything in packages directory
-  packageOverlays = builtins.listToAttrs
-    (builtins.attrValues (builtins.mapAttrs makePackage entries));
-
-in
-packageOverlays
+# Auto-import all packages from the packages directory
+super.lib.mapAttrs'
+  (name: _: super.lib.nameValuePair
+    (super.lib.removeSuffix ".nix" name)
+    (self.callPackage (packages + "/${name}") { }))
+  (builtins.readDir packages)

--- a/packages/compress-video.nix
+++ b/packages/compress-video.nix
@@ -1,4 +1,4 @@
-{ writeShellApplication, ffmpeg-full, ... }:
+{ writeShellApplication, ffmpeg, ... }:
 
 writeShellApplication {
   name = "compress-video";
@@ -7,7 +7,7 @@ writeShellApplication {
     Usage: compress-video input.mov [target_size_mb]
     Default target size is 900MB.
   '';
-  runtimeInputs = [ ffmpeg-full ];
+  runtimeInputs = [ ffmpeg ];
   text = ''
     input="$1"
     target_mb="''${2:-900}"

--- a/packages/fuckport.nix
+++ b/packages/fuckport.nix
@@ -8,12 +8,21 @@ writeShellApplication {
   runtimeInputs = [ lsof ];
   text = ''
     for port in "$@"; do
-      # -t prints bare PIDs; no JSON round-trip needed. lsof exits non-zero
+      pid=""
+      # -F pc emits one "p<pid>" line and one "c<command>" line per process,
+      # so we get the name without shelling out to ps. lsof exits non-zero
       # when nothing is listening, which is not an error for us.
-      for pid in $(lsof -t -i ":$port" || true); do
-        echo "Killing $pid ($(ps -p "$pid" -o comm= || echo '?')) on port $port"
-        kill -KILL "$pid"
-      done
+      while read -r line; do
+        case "$line" in
+          p*) pid="''${line#p}" ;;
+          c*)
+            [ -n "$pid" ] || continue
+            echo "Killing $pid (''${line#c}) on port $port"
+            kill -KILL "$pid"
+            pid=""
+            ;;
+        esac
+      done < <(lsof -F pc -i ":$port" || true)
     done
   '';
 }

--- a/packages/fuckport.nix
+++ b/packages/fuckport.nix
@@ -1,40 +1,19 @@
+# Kill whatever is listening on the given port(s).
 # https://x.com/sridca/status/1861875950897578113
-{ writers, haskellPackages, coreutils, jc, lsof, ... }:
+{ writeShellApplication, lsof, ... }:
 
-writers.writeHaskellBin "fuckport"
-{
-  libraries = with haskellPackages; [
-    shh
-    aeson
-  ];
-} ''
-  {-# LANGUAGE TemplateHaskell #-}
-  {-# LANGUAGE DerivingStrategies #-}
-  {-# LANGUAGE DeriveAnyClass #-}
-  import Shh
-  import System.Environment
-  import Data.Aeson
-  import Data.Maybe
-  import GHC.Generics
-  import Control.Monad
-
-  loadFromBins ["${lsof}", "${coreutils}", "${jc}"]
-
-  data LsofRow = LsofRow
-    { command :: String
-    , pid :: Int
-    , user :: String
-    }
-    deriving stock (Generic, Show)
-    deriving anyclass (FromJSON)
-
-  main :: IO ()
-  main = do
-    ports <- getArgs
-    forM_ ports $ \port -> do
-      s <- lsof "-i" (":" <> port) |> jc "--lsof" |> capture
-      let v = fromJust $ decode @[LsofRow] s
-      forM_ v $ \r -> do
-        putStrLn $ "Killing " <> show (pid r) <> " (" <> command r <> ") on port " <> port
-        kill ["-KILL", show (pid r)]
-''
+writeShellApplication {
+  name = "fuckport";
+  meta.description = "Kill the process(es) listening on the given port(s)";
+  runtimeInputs = [ lsof ];
+  text = ''
+    for port in "$@"; do
+      # -t prints bare PIDs; no JSON round-trip needed. lsof exits non-zero
+      # when nothing is listening, which is not an error for us.
+      for pid in $(lsof -t -i ":$port" || true); do
+        echo "Killing $pid ($(ps -p "$pid" -o comm= || echo '?')) on port $port"
+        kill -KILL "$pid"
+      done
+    done
+  '';
+}


### PR DESCRIPTION
Cleanup pass over all `.nix` files, from four review passes (reuse,
simplification, efficiency, altitude). Net **-118 lines**.

## Does this change behaviour?

I diffed the *evaluated* config (not just the derivations, which all shift
because the source hash changes) for every host, before vs after. Full results
below; the short version is **four intentional changes, nothing else**.

### 1. `kill-audit.nix` — naiveintent only, intentional

The `kill` rules already filtered on the signal; the `tkill`/`tgkill`/
`pidfd_send_signal` rule did not. `tgkill` is how the Go runtime delivers
`SIGURG` for async preemption — `sysmon` retakes every busy P roughly every
10ms — so on a box running `tailscaled` and `incusd` every one of those became
a SYSCALL record in `/var/log/audit`. The file's own header says the intent is
SIGTERM/SIGKILL.

The signal's argument index differs per syscall, so the rules are split
accordingly:

| syscall | signature | signal arg |
|---|---|---|
| `kill(pid, sig)` | 2 args | `a1` |
| `tkill(tid, sig)` | 2 args | `a1` |
| `pidfd_send_signal(pidfd, sig, info, flags)` | 4 args | `a1` |
| `tgkill(tgid, tid, sig)` | 3 args | `a2` |

**You now audit strictly less.** SIGTERM/SIGKILL through all four syscalls are
still recorded; other signals through the `tkill` family are not. If you wanted
the firehose, revert this hunk.

> Fixed in 86faec8 after review: my first version filtered all three of
> `tkill`/`tgkill`/`pidfd_send_signal` on `a2`, which only matches `tgkill`.
> For `tkill`, `a2` is an unused register; for `pidfd_send_signal` it is the
> `siginfo_t` pointer, so it is never 9 or 15. That silently dropped
> SIGTERM/SIGKILL for those two syscalls — and since systemd v247+ prefers
> `pidfd_send_signal` for unit TERM/KILL, that was the common case.

### 2. `fuckport` — reimplemented

Was `writers.writeHaskellBin` shelling out to `jc` to turn `lsof` output into
JSON just to read the `pid` field. `jc` is Python, so **every host and
container carried a Python 3.14 interpreter, Pygments and ruamel-yaml** for
this. `lsof -t` already prints bare PIDs.

Closure: **250.1 MiB → 38.0 MiB.** Also drops GHC from the build.

Same UX: the "Killing …" line still reports the process name, read from
`lsof -F pc` rather than from `jc`'s JSON.

Tested against a free port (exits 0), a single listener, two listeners sharing
a port via `SO_REUSEPORT`, and several ports in one invocation.

> Two drafts of this were wrong before it settled. The first regressed the
> free-port case to exit 1 under `set -e`. The second used `ps -p` for the
> process name without putting it in `runtimeInputs`, so the name would have
> fallen back to `?` unless the caller's PATH happened to supply `ps` (caught
> in review). `lsof -F pc` avoids both: self-contained, one `lsof` call
> instead of one plus N `ps` forks, and no dependency on `procps` — which
> resolves to a different, unsupported derivation on darwin, where this ships
> via `terminal.nix`.

### 3. `compress-video` — `ffmpeg-full` → `ffmpeg`

The script only uses `ffmpeg`/`ffprobe`. `ffmpeg-full` is the thing that
`terminal.nix` already comments out as "fails to build (kvazaar test
failures)", but autoWire still evaluates and builds it in CI. 1.5 GiB → 1.0 GiB
and it builds. Not installed on any host, so this only affects
`nix build .#compress-video` / CI.

The note in `terminal.nix` that kept it commented out cited the `ffmpeg-full`
kvazaar failure, which no longer applies. I corrected the note rather than
re-enabling the package: plain `ffmpeg` is still a ~1 GiB closure that
`terminal.nix` would put on *every* host. Say the word if you'd rather have it
on `$PATH`.

### 4. `buildMachines` `sshKey` — same value today, more general

`pureintent.nix` (a *Linux* builder) hardcoded `/Users/srid/.ssh/...` and
`sincereintent.nix` (a *darwin* builder) hardcoded `/home/srid/.ssh/...` —
i.e. each encoded the consumer's home dir, making them silently
platform-locked in the direction opposite to their filenames. Now both use
`config.home.homeDirectory`.

Verified this evaluates to the identical string on both current consumers:
zest (darwin) still gets `/Users/srid/.ssh/nix-remote-builder`, pureintent
still gets `/home/srid/...`.

### Everything else: no behavioural change

Evaluated-config diff across all 8 configurations, and the only remaining
deltas are duplicate list entries collapsing:

```
 environment.systemPackages / home.packages:
-  "just-1.58.0",          # was installed by both terminal.nix and just.nix
-  "zellij-one",           # was installed by both terminal.nix and zest
 users.users.srid.extraGroups:
-  "networkmanager", "wheel",   # the pair was listed twice
```

- `myolai` — **bit-identical derivation** (`6w11xvv…` before and after).
- `infinitude-macos` — evaluated config **identical**.
- `pureintent` / `naiveintent` — only the audit rules and the dedups above.
- home configs — only the dedups above.

Notably identical: firewall ports and trusted interfaces, the sudo rule,
`nix.settings`, openssh/tailscale/nix-ld, timezone, allowUnfree, shells,
authorized keys, `nix.buildMachines`, and `programs.direnv.nix-direnv.package`
(confirming the `override` I removed was a no-op — `config.nix.package` is
already nix-direnv's own default).

## What changed structurally

**`modules/nixos/linux/my-workstation.nix` (new).** `pureintent` and
`naiveintent` were structurally the same file — ~45 byte-identical lines. The
`localPrivilegeMode` + `security.sudo.extraRules` NOPASSWD pair is the sharp
edge: two separate statements that only work together, so a third host
setting one without the other gets deploys that silently prompt or fail. They
now live in one module. Each host file keeps only what actually differs
(sshTarget, swap policy, extra ports, extra modules) and drops ~50 lines.

They had already drifted, which is the argument for doing it: `zramSwap` and
`allowedTCPPorts` differ between the two, and `nix-ld` carries a different
justifying comment on each.

**Redundant settings removed.** Both hosts import `nixosModules.default`, so
these were re-statements: `allowUnfree` (`shared/nix.nix`), `time.timeZone`
(`linux/current-location.nix`), `isNormalUser`/`extraGroups`
(`shared/primary-as-admin.nix`), and a second `services.openssh.enable` set
twice on the *same host* in two files.

**`modules/work/pu.nix` (new).** `puHost = "10.10.68.56"` was pinned in both
`modules/home/work/juspay-run.nix` and `modules/nixos/linux/devbox.nix` — two
different layers — with a comment in one saying "Same pin as …" doing the job
a binding should. Per the linked xyne-boxes PR that IP is temporary. Same for
the four-line `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY`/`PU_HOST` preamble.

**`primary-as-admin.nix`** assigned `shell = pkgs.zsh` and then discarded it
via `//` with `shell = pkgs.bash` on Linux. Same result, but it reads like a
bug; now an explicit conditional.

**Mechanical:** `lib.genAttrs` for the repeated per-host SSH blocks in
`controlpersist.nix` (3 identical copies) and `1password.nix`; `mapAttrs'` +
`removeSuffix` for the `packages/` walk in `overlays/default.nix`; the
loop+flag in `pi.nix` reduced to a loop without the flag; unused module
arguments dropped from 6 files; `with builtins` wrapper dropped in `flake.nix`.

> I first rewrote the `pi.nix` probe as `case " $* " in *" --model "*)`, which
> review correctly flagged as **not** equivalent: an argument merely
> *containing* the text — `pi "explain the --model flag"` — counted as the
> user having passed the flag and silently skipped the `litellm/kimi-k3`
> default. Reverted to token-exact matching in 4c83658.

## Not done — wants your call

**~735 lines (20% of the tree) are unreachable.** 26 module files that nothing
imports: the whole `AI/` tree, `modules/nixos/linux/{distributed-build,docker,
hedgedoc,nixos-container,parallels-vm,passwordstore,eternal-terminal}.nix`,
`disko/*`, `server/{harden/*,unlaptop,wakeonlan}.nix`,
`home/services/{syncthing,vira,email/*}.nix`, `home/gui/ghostty.nix`,
`darwin/all/thunderbird.nix`, plus files reachable only from a commented-out
import (`zellij.nix`, `dropbox.nix`, `helix.nix`, `vscode-server.nix`,
`claude-code/juspay.nix`).

I left all of it alone — several are clearly deliberate "off for now" toggles
and deleting 26 files is your call, not mine. Worth knowing it distorts the
picture though: `distributed-build.nix` is a dead third copy of the pureintent
builder config with a *different* `sshKey` path, and `server/harden/basics.nix`
sets `PermitRootLogin = "no"` while the live `primary-as-admin.nix` installs
root authorized keys — an apparent contradiction that only resolves once you
notice one file is dead.

Related: `services/ttyd.nix` is a 54-line hand-written options module imported
into *every* home config with `enable` never set anywhere; and three flake
inputs (`disko`, `nixos-hardware`, `git-hooks`) are locked and fetched but
referenced nowhere.

**Also skipped:** `secrets/secrets.nix` `genAttrs` (needs `lib` in a file
agenix evaluates standalone); precomputing the 5 `eval "$(… init bash)"` shell
hooks (~15 ms/shell, but real churn); moving `SSH_AUTH_SOCK` out of the
(disabled) zellij settings in `ssh-agent-forwarding.nix`, since setting it
globally could break the 1Password agent; and `packages/twitter-convert`,
where `bc` is genuinely missing from `runtimeInputs` — a real bug, so out of
scope for a cleanup PR.

## Verification

`nix flake check` passes. All 8 configurations evaluate
(3 NixOS, 4 home, 1 darwin). `fuckport` and `compress-video` build,
`fuckport` was smoke-tested against a live listener and a free port, and
`nix run .#compress-video` runs.
Not deployed — no `just activate` run.

Unrelated pre-existing bug spotted while testing: `compress-video` with no
arguments dies on `$1: unbound variable` under `set -u`, so its usage message
is unreachable. Left alone — not this PR's scope.
